### PR TITLE
publish command receive the draft path

### DIFF
--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -3,7 +3,7 @@ module Jekyll
     class Publish < Command
       def self.init_with_program(prog)
         prog.command(:publish) do |c|
-          c.syntax 'publish NAME'
+          c.syntax 'publish DRAFT_PATH'
           c.description 'Moves a draft into the _posts directory and sets the date'
 
           c.option 'date', '-d DATE', '--date DATE', 'Specify the post date'
@@ -15,16 +15,18 @@ module Jekyll
       end
 
       def self.process(args, options = {})
-        raise ArgumentError.new('You must specify a name.') if args.empty?
-        
+        raise ArgumentError.new('You must specify a draft path.') if args.empty?
+
         date = options["date"].nil? ? Date.today : Date.parse(options["date"])
-        file = args.shift
+        draft_path = args.shift
 
-        post_path = post_name(date, file)
-        FileUtils.mv(draft_name(file), post_path)
+        raise ArgumentError.new("There was no draft found at '#{draft_path}'.") unless File.exist? draft_path
 
-        puts "Draft #{file} was published to ./#{post_path}"
-      end 
+        post_path = post_name(date, draft_name(draft_path))
+        FileUtils.mv(draft_path, post_path)
+
+        puts "Draft #{draft_path} was published to ./#{post_path}"
+      end
 
       # Internal: Gets the filename of the post to be created
       #
@@ -33,8 +35,8 @@ module Jekyll
         "_posts/#{date.strftime('%Y-%m-%d')}-#{name}"
       end
 
-      def self.draft_name(name)
-        "_drafts/#{name}"
+      def self.draft_name(path)
+        File.basename(path)
       end
 
     end


### PR DESCRIPTION
This change a little bit the publish command.

I think it make sense for the `post` and `draft` command to receive the name (title) of the post.. that way you can create the file in the corresponding folder.

But for `publish` it makes more sense to pass the entire path of the draft you want to publish. This is because this way you can use the autocomplete `jekyll publish _drafts/my-draft-post.md`. I think is easier.
