### PR TITLE
Updated readme with command help and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,28 @@ Or install it yourself as:
 
 Install `jekyll-compose` and run `jekyll help`.
 
+Listed in help you will see new commands available to you:
+
+```sh
+  draft                 Creates a new draft post with the given NAME
+  post                  Creates a new post with the given NAME
+  publish               Moves a draft into the _posts directory and sets the date
+```
+
+Create your new post using:
+
+    $ jekyll post "My New Post"
+
+## Helpful Note
+
+If after installing the jekyll-compose gem you still do not see the above commands avaiable to you, try including the gem in the jekyll_plugins group of your Gemfile like so:
+
+```ruby
+group :jekyll_plugins do
+  gem 'jekyll-compose'
+end
+```
+
 ## Contributing
 
 1. Fork it ( http://github.com/<my-github-username>/jekyll-compose/fork )


### PR DESCRIPTION
Updating the readme:

- Provides assistance for the "I can't see jekyll compose commands" issue (https://github.com/jekyll/jekyll-compose/issues/4).

- Also adding a basic usage example to make clear the commands available. (I initially expected I would run `jekyll compose draft "My New Draft"`)