### PR TITLE
Create _drafts folder if it does not exist

### DIFF
--- a/lib/jekyll-compose/version.rb
+++ b/lib/jekyll-compose/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Compose
-    VERSION = "0.2.0"
+    VERSION = "0.2.1"
   end
 end

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -19,6 +19,8 @@ module Jekyll
       def self.process(args = [], options = {})
         raise ArgumentError.new('You must specify a name.') if args.empty?
 
+        Dir.mkdir("_drafts") unless Dir.exist?("_drafts")
+
         type = options["type"] || Jekyll::Compose::DEFAULT_TYPE
         layout = options["layout"] || Jekyll::Compose::DEFAULT_LAYOUT
 


### PR DESCRIPTION
Thanks for writing up this compose tool. It was something I realized I wanted and was happy to see already existed! I noticed that running the draft command threw an error on a clean install and put together a fix. I updated the version number simply because it seemed like the thing to do.

When using the drafts command, if the _drafts folder does not already exist, create it. This prevents errors when running the draft command for the first time on Jekyll 2.5.3.

Before:
```sh
10:00:26 ~/projects/compose-test > jekyll draft "My New Draft"
jekyll 2.5.3 | Error:  No such file or directory @ rb_sysopen - _drafts/my-new-draft.md
```

After:
```sh
10:03:11 ~/projects/compose-test > jekyll draft "My New Draft"
New draft created at ./_drafts/my-new-draft.md.
```
