### PR TITLE
Ensure colons do not break titles

### DIFF
--- a/lib/jekyll-compose/file_info.rb
+++ b/lib/jekyll-compose/file_info.rb
@@ -13,8 +13,18 @@ class Jekyll::Compose::FileInfo
     <<-CONTENT.gsub /^\s+/, ''
       ---
       layout: #{params.layout}
-      title: #{params.title}
+      title: #{yaml_clean_title}
       ---
     CONTENT
+  end
+
+  private
+
+  def yaml_clean_title
+    if params.title.include? ':'
+      '"' + params.title + '"'
+    else
+      params.title
+    end
   end
 end

--- a/lib/jekyll-compose/file_info.rb
+++ b/lib/jekyll-compose/file_info.rb
@@ -10,21 +10,11 @@ class Jekyll::Compose::FileInfo
   end
 
   def content
-    <<-CONTENT.gsub /^\s+/, ''
-      ---
-      layout: #{params.layout}
-      title: #{yaml_clean_title}
-      ---
-    CONTENT
-  end
+    front_matter = YAML.dump({
+      'layout' => params.layout,
+      'title' => params.title,
+    })
 
-  private
-
-  def yaml_clean_title
-    if params.title.include? ':'
-      '"' + params.title + '"'
-    else
-      params.title
-    end
+    front_matter + "---\n"
   end
 end

--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe(Jekyll::Compose::FileInfo) do
       let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
           ---
           layout: post
-          title: "A test: arg parser"
+          title: 'A test: arg parser'
           ---
         CONTENT
       }

--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -1,0 +1,46 @@
+RSpec.describe(Jekyll::Compose::FileInfo) do
+  describe '#content' do
+    context 'with a title of only words' do
+      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
+          ---
+          layout: post
+          title: A test arg parser
+          ---
+        CONTENT
+      }
+
+      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
+          ['A test arg parser'],
+          {}
+        )
+      }
+
+      it 'does not wrap the title in quotes' do
+        file_info = described_class.new parsed_args
+        expect(file_info.content).to eq(expected_result)
+      end
+    end
+
+    context 'with a title that includes a colon' do
+      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
+          ---
+          layout: post
+          title: "A test: arg parser"
+          ---
+        CONTENT
+      }
+
+      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
+          ['A test: arg parser'],
+          {}
+        )
+      }
+
+      it 'does wrap the title in quotes' do
+        file_info = described_class.new parsed_args
+        expect(file_info.content).to eq(expected_result)
+      end
+    end
+  end
+end
+

--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -1,44 +1,37 @@
 RSpec.describe(Jekyll::Compose::FileInfo) do
+  let(:open_and_closing_tag) { "---\n" }
+  let(:layout_content) { "post\n" }
+
   describe '#content' do
     context 'with a title of only words' do
-      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
-          ---
-          layout: post
-          title: A test arg parser
-          ---
-        CONTENT
-      }
-
-      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
+      let(:expected_title) { "A test arg parser\n" }
+      subject { described_class.new Jekyll::Compose::ArgParser.new(
           ['A test arg parser'],
           {}
         )
       }
 
       it 'does not wrap the title in quotes' do
-        file_info = described_class.new parsed_args
-        expect(file_info.content).to eq(expected_result)
+        expect(subject.content).to start_with(open_and_closing_tag)
+        expect(subject.content).to end_with(open_and_closing_tag)
+        expect(subject.content).to match(layout_content)
+        expect(subject.content).to match(expected_title)
       end
     end
 
     context 'with a title that includes a colon' do
-      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
-          ---
-          layout: post
-          title: 'A test: arg parser'
-          ---
-        CONTENT
-      }
-
-      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
+      let(:expected_title) { "'A test: arg parser'\n" }
+      subject { described_class.new Jekyll::Compose::ArgParser.new(
           ['A test: arg parser'],
           {}
         )
       }
 
       it 'does wrap the title in quotes' do
-        file_info = described_class.new parsed_args
-        expect(file_info.content).to eq(expected_result)
+        expect(subject.content).to start_with(open_and_closing_tag)
+        expect(subject.content).to end_with(open_and_closing_tag)
+        expect(subject.content).to match(layout_content)
+        expect(subject.content).to match(expected_title)
       end
     end
   end

--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -1,37 +1,44 @@
 RSpec.describe(Jekyll::Compose::FileInfo) do
-  let(:open_and_closing_tag) { "---\n" }
-  let(:layout_content) { "post\n" }
-
   describe '#content' do
     context 'with a title of only words' do
-      let(:expected_title) { "A test arg parser\n" }
-      subject { described_class.new Jekyll::Compose::ArgParser.new(
+      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
+          ---
+          layout: post
+          title: A test arg parser
+          ---
+        CONTENT
+      }
+
+      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
           ['A test arg parser'],
           {}
         )
       }
 
       it 'does not wrap the title in quotes' do
-        expect(subject.content).to start_with(open_and_closing_tag)
-        expect(subject.content).to end_with(open_and_closing_tag)
-        expect(subject.content).to match(layout_content)
-        expect(subject.content).to match(expected_title)
+        file_info = described_class.new parsed_args
+        expect(file_info.content).to eq(expected_result)
       end
     end
 
     context 'with a title that includes a colon' do
-      let(:expected_title) { "'A test: arg parser'\n" }
-      subject { described_class.new Jekyll::Compose::ArgParser.new(
+      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
+          ---
+          layout: post
+          title: 'A test: arg parser'
+          ---
+        CONTENT
+      }
+
+      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
           ['A test: arg parser'],
           {}
         )
       }
 
       it 'does wrap the title in quotes' do
-        expect(subject.content).to start_with(open_and_closing_tag)
-        expect(subject.content).to end_with(open_and_closing_tag)
-        expect(subject.content).to match(layout_content)
-        expect(subject.content).to match(expected_title)
+        file_info = described_class.new parsed_args
+        expect(file_info.content).to eq(expected_result)
       end
     end
   end


### PR DESCRIPTION
When titles have colons in them, it breaks the liquid template.
This encapsulates the titles in string literals if the user
wants a title with a colon in it.

Closes #38