### PR TITLE
Allow additional front matter for Post

### DIFF
--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -66,6 +66,11 @@ module Jekyll
         def content(custom_front_matter = {})
           super({ "date" => _time_stamp }.merge(custom_front_matter))
         end
+
+        def content
+          post_front_matter = Jekyll.configuration["post_front_matter"]
+          super post_front_matter
+        end
       end
     end
   end

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -64,12 +64,17 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
+          if jekyll_compose_config && jekyll_compose_config["post_default_front_matter"]
+            custom_front_matter.merge!(jekyll_compose_config["post_default_front_matter"])
+          end
+
           super({ "date" => _time_stamp }.merge(custom_front_matter))
         end
 
-        def content
-          post_front_matter = Jekyll.configuration["post_front_matter"]
-          post_front_matter ? super(post_front_matter) : super
+        private
+
+        def jekyll_compose_config
+          @jekyll_compose_config ||= Jekyll.configuration["jekyll_compose"]
         end
       end
     end

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -64,17 +64,16 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          if jekyll_compose_config && jekyll_compose_config["post_default_front_matter"]
-            custom_front_matter.merge!(jekyll_compose_config["post_default_front_matter"])
-          end
+          default_front_matter = compose_config["post_default_front_matter"]
+          custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super({ "date" => _time_stamp }.merge(custom_front_matter))
         end
 
         private
 
-        def jekyll_compose_config
-          @jekyll_compose_config ||= Jekyll.configuration["jekyll_compose"]
+        def compose_config
+          @compose_config ||= Jekyll.configuration["jekyll_compose"] || {}
         end
       end
     end

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -69,7 +69,7 @@ module Jekyll
 
         def content
           post_front_matter = Jekyll.configuration["post_front_matter"]
-          super post_front_matter
+          post_front_matter ? super(post_front_matter) : super
         end
       end
     end

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,0 +1,3 @@
+post_front_matter:
+  description: my description
+  category:

--- a/spec/fixtures/_config.yml
+++ b/spec/fixtures/_config.yml
@@ -1,3 +1,0 @@
-post_front_matter:
-  description: my description
-  category:

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe(Jekyll::Commands::Post) do
   let(:timestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
   let(:filename) { "#{datestamp}-a-test-post.md" }
   let(:path) { posts_dir.join(filename) }
+  let(:jekyll_config) { YAML.load_file('../fixtures/_config.yml') }
 
   before(:all) do
     FileUtils.mkdir_p source_dir unless File.directory? source_dir
@@ -47,6 +48,13 @@ RSpec.describe(Jekyll::Commands::Post) do
   it "creates a new post with the specified layout" do
     capture_stdout { described_class.process(args, "layout" => "other-layout") }
     expect(File.read(path)).to match(%r!layout: other-layout!)
+  end
+
+  it 'creates a new page with the specified config' do
+    expect(Jekyll).to receive(:configuration).and_return(jekyll_config)
+    capture_stdout { described_class.process(args) }
+    expect(File.read(path)).to match(/description: my description/)
+    expect(File.read(path)).to match(/category: /)
   end
 
   it "should write a helpful message when successful" do

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -8,7 +8,6 @@ RSpec.describe(Jekyll::Commands::Post) do
   let(:timestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
   let(:filename) { "#{datestamp}-a-test-post.md" }
   let(:path) { posts_dir.join(filename) }
-  let(:jekyll_config) { YAML.load_file('../fixtures/_config.yml') }
 
   before(:all) do
     FileUtils.mkdir_p source_dir unless File.directory? source_dir
@@ -48,13 +47,6 @@ RSpec.describe(Jekyll::Commands::Post) do
   it "creates a new post with the specified layout" do
     capture_stdout { described_class.process(args, "layout" => "other-layout") }
     expect(File.read(path)).to match(%r!layout: other-layout!)
-  end
-
-  it 'creates a new page with the specified config' do
-    expect(Jekyll).to receive(:configuration).and_return(jekyll_config)
-    capture_stdout { described_class.process(args) }
-    expect(File.read(path)).to match(/description: my description/)
-    expect(File.read(path)).to match(/category: /)
   end
 
   it "should write a helpful message when successful" do
@@ -121,13 +113,23 @@ RSpec.describe(Jekyll::Commands::Post) do
       expect(path).to exist
     end
 
-    context "auto_open editor is set" do
+    context "configuration is set" do
       let(:posts_dir) { Pathname.new source_dir("_posts") }
       let(:config_data) do
         %(
       jekyll_compose:
         auto_open: true
+        post_default_front_matter:
+          description: my description
+          category:
       )
+      end
+
+      it "creates post with the specified config" do
+        capture_stdout { described_class.process(args) }
+        post = File.read(path)
+        expect(post).to match(%r!description: my description!)
+        expect(post).to match(%r!category: !)
       end
 
       context "env variable EDITOR is set up" do


### PR DESCRIPTION
Currently, jekyll-compose `post` command generates only `layout` and `title` as front matter, but I'd like to add more front matters. For example:

``` yaml

---
layout: post
title: Blogging Like a Hacker
published: true
description: 
category: 

---
```

This PR adds feature that allows addtional front matter loaded from Jekyll's `_config.yml` for `jekyll post` command.

`_config.yml` sample is like:

``` yaml
# _config.yml

# jekyll-compose
jekyll_compose:
  post_default_front_matter:
    published: true
    foo: bar
    category: 
```