### PR TITLE
Allow Jekyll Source Directory

### DIFF
--- a/lib/jekyll-compose/arg_parser.rb
+++ b/lib/jekyll-compose/arg_parser.rb
@@ -1,8 +1,9 @@
 class Jekyll::Compose::ArgParser
-  attr_reader :args, :options
+  attr_reader :args, :options, :config
   def initialize(args, options)
     @args = args
     @options = options
+    @config = Jekyll.configuration(options)
   end
 
   def validate!
@@ -23,5 +24,9 @@ class Jekyll::Compose::ArgParser
 
   def force?
     !!options["force"]
+  end
+
+  def source
+    source = config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
   end
 end

--- a/lib/jekyll-compose/arg_parser.rb
+++ b/lib/jekyll-compose/arg_parser.rb
@@ -11,11 +11,11 @@ class Jekyll::Compose::ArgParser
   end
 
   def type
-    type = options["extension"] || Jekyll::Compose::DEFAULT_TYPE
+    options["extension"] || Jekyll::Compose::DEFAULT_TYPE
   end
 
   def layout
-    layout = options["layout"] || Jekyll::Compose::DEFAULT_LAYOUT
+    options["layout"] || Jekyll::Compose::DEFAULT_LAYOUT
   end
 
   def title
@@ -27,6 +27,6 @@ class Jekyll::Compose::ArgParser
   end
 
   def source
-    source = config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
+    config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
   end
 end

--- a/lib/jekyll-compose/file_creator.rb
+++ b/lib/jekyll-compose/file_creator.rb
@@ -1,10 +1,11 @@
 module Jekyll
   module Compose
     class FileCreator
-      attr_reader :file, :force
-      def initialize(fileInfo, force = false)
+      attr_reader :file, :force, :root
+      def initialize(fileInfo, force = false, root = nil)
         @file = fileInfo
         @force = force
+        @root = root
       end
 
       def create!
@@ -16,20 +17,25 @@ module Jekyll
       private
 
       def validate_should_write!
-        raise ArgumentError.new("A #{file.resource_type} already exists at #{file.path}") if File.exist?(file.path) and !force
+        raise ArgumentError.new("A #{file.resource_type} already exists at #{file_path}") if File.exist?(file_path) and !force
       end
 
       def ensure_directory_exists
-        dir = File.dirname file.path
+        dir = File.dirname file_path
         Dir.mkdir(dir) unless Dir.exist?(dir)
       end
 
       def write_file
-        File.open(file.path, "w") do |f|
+        File.open(file_path, "w") do |f|
           f.puts(file.content)
         end
 
-        puts "New #{file.resource_type} created at #{file.path}."
+        puts "New #{file.resource_type} created at #{file_path}."
+      end
+
+      def file_path
+        return file.path if root.nil? or root.empty?
+        return File.join(root, file.path)
       end
     end
   end

--- a/lib/jekyll-compose/file_mover.rb
+++ b/lib/jekyll-compose/file_mover.rb
@@ -33,7 +33,7 @@ module Jekyll
 
       private
       def from
-        file_path(movement.from)
+        movement.from
       end
 
       def to

--- a/lib/jekyll-compose/file_mover.rb
+++ b/lib/jekyll-compose/file_mover.rb
@@ -1,9 +1,10 @@
 module Jekyll
   module Compose
     class FileMover
-      attr_reader :movement
-      def initialize(movement)
+      attr_reader :movement, :root
+      def initialize(movement, root = nil)
         @movement = movement
+        @root = root
       end
 
       def resource_type
@@ -17,17 +18,31 @@ module Jekyll
       end
 
       def validate_source
-        raise ArgumentError.new("There was no #{resource_type} found at '#{movement.from}'.") unless File.exist? movement.from
+        raise ArgumentError.new("There was no #{resource_type} found at '#{from}'.") unless File.exist? from
       end
 
       def ensure_directory_exists
-        dir = File.dirname movement.to
+        dir = File.dirname to
         Dir.mkdir(dir) unless Dir.exist?(dir)
       end
 
       def move_file
-        FileUtils.mv(movement.from, movement.to)
-        puts "#{resource_type.capitalize} #{movement.from} was moved to #{movement.to}"
+        FileUtils.mv(from, to)
+        puts "#{resource_type.capitalize} #{from} was moved to #{to}"
+      end
+
+      private
+      def from
+        file_path(movement.from)
+      end
+
+      def to
+        file_path(movement.to)
+      end
+
+      def file_path(path)
+        return path if root.nil? or root.empty?
+        return File.join(root, path)
       end
     end
   end

--- a/lib/jekyll-compose/movement_arg_parser.rb
+++ b/lib/jekyll-compose/movement_arg_parser.rb
@@ -1,10 +1,11 @@
 module Jekyll
   module Compose
     class MovementArgParser
-      attr_reader :args, :options
+      attr_reader :args, :options, :config
       def initialize(args, options)
         @args = args
         @options = options
+        @config = Jekyll.configuration(options)
       end
 
       def validate!
@@ -13,6 +14,10 @@ module Jekyll
 
       def path
         args.join ' '
+      end
+
+      def source
+        source = config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
       end
     end
   end

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -24,16 +24,12 @@ module Jekyll
 
 
       def self.process(args = [], options = {})
-        config = configuration_from_options(options)
-
         params = Compose::ArgParser.new args, options
         params.validate!
 
         draft = DraftFileInfo.new params
 
-        root = config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
-
-        Compose::FileCreator.new(draft, params.force?, root).create!
+        Compose::FileCreator.new(draft, params.force?, params.source).create!
       end
 
       class DraftFileInfo < Compose::FileInfo

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -16,18 +16,24 @@ module Jekyll
         [
           ['extension', '-x EXTENSION', '--extension EXTENSION', 'Specify the file extension'],
           ['layout', '-l LAYOUT', '--layout LAYOUT', "Specify the draft layout"],
-          ['force', '-f', '--force', 'Overwrite a draft if it already exists']
+          ['force', '-f', '--force', 'Overwrite a draft if it already exists'],
+          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'],
+          ['source', '-s', '--source SOURCE', 'Custom source directory'],
         ]
       end
 
 
       def self.process(args = [], options = {})
+        config = configuration_from_options(options)
+
         params = Compose::ArgParser.new args, options
         params.validate!
 
         draft = DraftFileInfo.new params
 
-        Compose::FileCreator.new(draft, params.force?).create!
+        root = config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
+
+        Compose::FileCreator.new(draft, params.force?, root).create!
       end
 
       class DraftFileInfo < Compose::FileInfo

--- a/lib/jekyll/commands/page.rb
+++ b/lib/jekyll/commands/page.rb
@@ -16,7 +16,9 @@ module Jekyll
         [
           ['extension', '-x EXTENSION', '--extension EXTENSION', 'Specify the file extension'],
           ['layout', '-l LAYOUT', '--layout LAYOUT', "Specify the page layout"],
-          ['force', '-f', '--force', 'Overwrite a page if it already exists']
+          ['force', '-f', '--force', 'Overwrite a page if it already exists'],
+          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'],
+          ['source', '-s', '--source SOURCE', 'Custom source directory'],
         ]
       end
 
@@ -26,7 +28,7 @@ module Jekyll
 
         page = PageFileInfo.new params
 
-        Compose::FileCreator.new(page, params.force?).create!
+        Compose::FileCreator.new(page, params.force?, params.source).create!
       end
 
       class PageArgParser < Compose::ArgParser

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -17,7 +17,9 @@ module Jekyll
           ['extension', '-x EXTENSION', '--extension EXTENSION', 'Specify the file extension'],
           ['layout', '-l LAYOUT', '--layout LAYOUT', "Specify the post layout"],
           ['force', '-f', '--force', 'Overwrite a post if it already exists'],
-          ['date', '-d DATE', '--date DATE', 'Specify the post date']
+          ['date', '-d DATE', '--date DATE', 'Specify the post date'],
+          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'],
+          ['source', '-s', '--source SOURCE', 'Custom source directory'],
         ]
       end
 
@@ -27,7 +29,7 @@ module Jekyll
 
         post = PostFileInfo.new params
 
-        Compose::FileCreator.new(post, params.force?).create!
+        Compose::FileCreator.new(post, params.force?, params.source).create!
       end
 
 

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -7,6 +7,8 @@ module Jekyll
           c.description 'Moves a draft into the _posts directory and sets the date'
 
           c.option 'date', '-d DATE', '--date DATE', 'Specify the post date'
+          c.option 'config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
+          c.option 'source', '-s', '--source SOURCE', 'Custom source directory'
 
           c.action do |args, options|
             Jekyll::Commands::Publish.process(args, options)
@@ -20,7 +22,7 @@ module Jekyll
 
         movement = DraftMovementInfo.new params
 
-        mover = DraftMover.new movement
+        mover = DraftMover.new movement, params.source
         mover.move
       end
 

--- a/lib/jekyll/commands/unpublish.rb
+++ b/lib/jekyll/commands/unpublish.rb
@@ -6,6 +6,9 @@ module Jekyll
           c.syntax 'unpublish POST_PATH'
           c.description 'Moves a post back into the _drafts directory'
 
+          c.option 'config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
+          c.option 'source', '-s', '--source SOURCE', 'Custom source directory'
+
           c.action do |args, options|
             process(args, options)
           end
@@ -18,7 +21,7 @@ module Jekyll
 
         movement = PostMovementInfo.new params
 
-        mover = PostMover.new movement
+        mover = PostMover.new movement, params.source
         mover.move
       end
 

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -73,4 +73,37 @@ RSpec.describe(Jekyll::Commands::Draft) do
       expect(File.read(path)).to match(/layout: post/)
     end
   end
+
+  context 'when a configuration file exists' do
+    let(:config) { source_dir('_config.yml') }
+    let(:drafts_dir) { Pathname.new source_dir(File.join('site', '_drafts')) }
+
+    before(:each) do
+      File.open(config, 'w') do |f|
+        f.write(%{
+source: site
+})
+      end
+    end
+
+    after(:each) do
+      FileUtils.rm(config)
+    end
+
+    it 'should use source directory set by config' do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(path).to exist
+    end
+  end
+
+  context 'when source option is set' do
+    let(:drafts_dir) { Pathname.new source_dir(File.join('site', '_drafts')) }
+
+    it 'should use source directory set by command line option' do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, 'source' => 'site') }
+      expect(path).to exist
+    end
+  end
 end

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -63,4 +63,37 @@ RSpec.describe(Jekyll::Commands::Page) do
       expect(File.read(path)).to match(/layout: page/)
     end
   end
+
+  context 'when a configuration file exists' do
+    let(:config) { source_dir('_config.yml') }
+    let(:path) { Pathname.new(source_dir).join('site', filename) }
+
+    before(:each) do
+      File.open(config, 'w') do |f|
+        f.write(%{
+source: site
+})
+      end
+    end
+
+    after(:each) do
+      FileUtils.rm(config)
+    end
+
+    it 'should use source directory set by config' do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(path).to exist
+    end
+  end
+
+  context 'when source option is set' do
+    let(:path) { Pathname.new(source_dir).join('site', filename) }
+
+    it 'should use source directory set by command line option' do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, 'source' => 'site') }
+      expect(path).to exist
+    end
+  end
 end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -82,4 +82,37 @@ RSpec.describe(Jekyll::Commands::Post) do
       expect(File.read(path)).to match(/layout: post/)
     end
   end
+
+  context 'when a configuration file exists' do
+    let(:config) { source_dir('_config.yml') }
+    let(:posts_dir) { Pathname.new source_dir('site', '_posts') }
+
+    before(:each) do
+      File.open(config, 'w') do |f|
+        f.write(%{
+source: site
+})
+      end
+    end
+
+    after(:each) do
+      FileUtils.rm(config)
+    end
+
+    it 'should use source directory set by config' do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(path).to exist
+    end
+  end
+
+  context 'when source option is set' do
+    let(:posts_dir) { Pathname.new source_dir('site', '_posts') }
+
+    it 'should use source directory set by command line option' do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, 'source' => 'site') }
+      expect(path).to exist
+    end
+  end
 end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -77,6 +77,8 @@ RSpec.describe(Jekyll::Commands::Publish) do
     let(:drafts_dir) { Pathname.new source_dir('site', '_drafts') }
     let(:posts_dir)  { Pathname.new source_dir('site', '_posts') }
 
+    let(:args) { ["site/_drafts/#{draft_to_publish}"] }
+
     before(:each) do
       File.open(config, 'w') do |f|
         f.write(%{
@@ -100,6 +102,8 @@ source: site
   context 'when source option is set' do
     let(:drafts_dir) { Pathname.new source_dir('site', '_drafts') }
     let(:posts_dir)  { Pathname.new source_dir('site', '_posts') }
+
+    let(:args) { ["site/_drafts/#{draft_to_publish}"] }
 
     it 'should use source directory set by command line option' do
       expect(post_path).not_to exist

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe(Jekyll::Commands::Publish) do
     output = capture_stdout { described_class.process(args) }
     expect(output).to eql("Draft _drafts/#{draft_to_publish} was moved to _posts/#{post_filename}\n")
   end
-  
+
   it 'publishes a draft on the specified date' do
     path = posts_dir.join "2012-03-04-a-test-post.md"
     capture_stdout { described_class.process(args, {"date" => '2012-3-4'}) }
@@ -72,4 +72,40 @@ RSpec.describe(Jekyll::Commands::Publish) do
     }).to raise_error("There was no draft found at '_drafts/i-do-not-exist.markdown'.")
   end
 
+  context 'when a configuration file exists' do
+    let(:config) { source_dir('_config.yml') }
+    let(:drafts_dir) { Pathname.new source_dir('site', '_drafts') }
+    let(:posts_dir)  { Pathname.new source_dir('site', '_posts') }
+
+    before(:each) do
+      File.open(config, 'w') do |f|
+        f.write(%{
+source: site
+})
+      end
+    end
+
+    after(:each) do
+      FileUtils.rm(config)
+    end
+
+    it 'should use source directory set by config' do
+      expect(post_path).not_to exist
+      expect(draft_path).to exist
+      capture_stdout { described_class.process(args) }
+      expect(post_path).to exist
+    end
+  end
+
+  context 'when source option is set' do
+    let(:drafts_dir) { Pathname.new source_dir('site', '_drafts') }
+    let(:posts_dir)  { Pathname.new source_dir('site', '_posts') }
+
+    it 'should use source directory set by command line option' do
+      expect(post_path).not_to exist
+      expect(draft_path).to exist
+      capture_stdout { described_class.process(args, 'source' => 'site') }
+      expect(post_path).to exist
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,6 +26,8 @@ RSpec.configure do |config|
 
   Kernel.srand config.seed
 
+  Jekyll.logger.log_level = :error
+
   ###
   ### Helper methods
   ###

--- a/spec/unpublish_spec.rb
+++ b/spec/unpublish_spec.rb
@@ -62,6 +62,8 @@ RSpec.describe(Jekyll::Commands::Unpublish) do
     let(:drafts_dir) { Pathname.new(source_dir('site', '_drafts')) }
     let(:posts_dir)  { Pathname.new(source_dir('site', '_posts')) }
 
+    let(:args) { ["site/_posts/#{post_filename}"] }
+
     before(:each) do
       File.open(config, 'w') do |f|
         f.write(%{
@@ -86,6 +88,8 @@ source: site
   context 'when source option is set' do
     let(:drafts_dir) { Pathname.new(source_dir('site', '_drafts')) }
     let(:posts_dir)  { Pathname.new(source_dir('site', '_posts')) }
+
+    let(:args) { ["site/_posts/#{post_filename}"] }
 
     it 'should use source directory set by command line option' do
       expect(post_path).to exist

--- a/spec/unpublish_spec.rb
+++ b/spec/unpublish_spec.rb
@@ -57,4 +57,42 @@ RSpec.describe(Jekyll::Commands::Unpublish) do
     }).to raise_error("There was no post found at '#{weird_path}'.")
   end
 
+  context 'when a configuration file exists' do
+    let(:config) { source_dir('_config.yml') }
+    let(:drafts_dir) { Pathname.new(source_dir('site', '_drafts')) }
+    let(:posts_dir)  { Pathname.new(source_dir('site', '_posts')) }
+
+    before(:each) do
+      File.open(config, 'w') do |f|
+        f.write(%{
+source: site
+})
+      end
+    end
+
+    after(:each) do
+      FileUtils.rm(config)
+    end
+
+    it 'should use source directory set by config' do
+      expect(post_path).to exist
+      expect(draft_path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(post_path).not_to exist
+      expect(draft_path).to exist
+    end
+  end
+
+  context 'when source option is set' do
+    let(:drafts_dir) { Pathname.new(source_dir('site', '_drafts')) }
+    let(:posts_dir)  { Pathname.new(source_dir('site', '_posts')) }
+
+    it 'should use source directory set by command line option' do
+      expect(post_path).to exist
+      expect(draft_path).not_to exist
+      capture_stdout { described_class.process(args, 'source' => 'site') }
+      expect(post_path).not_to exist
+      expect(draft_path).to exist
+    end
+  end
 end


### PR DESCRIPTION
Jekyll Compose assumes that the Jekyll code lives in the root directory, so if you have custom source set in your config, it won't respect that.

I've updated compose to load in configuration (adding both `--config` and `--source` options).