### PR TITLE
Execute FileInfo tests in source_dir, Fix tests

### DIFF
--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -1,4 +1,9 @@
 RSpec.describe(Jekyll::Compose::FileInfo) do
+  before(:all) do
+    FileUtils.mkdir_p source_dir unless File.directory? source_dir
+    Dir.chdir source_dir
+  end
+
   describe '#content' do
     context 'with a title of only words' do
       let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')


### PR DESCRIPTION
Due to some ArgParser specifics, the FileInfo test broke others when run
in the root project dir before others. This can be reproduced with
```
script/cibuild --order rand:22787
```
command.

I've created a before hook for FileInfo test which changes dir to
source_dir before running FileInfo tests. This fixes other tests
failing when running after FileInfo test