### PR TITLE
Inherit Jekyll's rubocop config for consistency

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,15 @@
+inherit_gem:
+  jekyll: .rubocop.yml
+
+Metrics/LineLength:
+  Exclude:
+    - spec/**/*
+    - jekyll-compose.gemspec
+
+Metrics/BlockLength:
+  Exclude:
+    - spec/**/*
+
+Style/IndentHeredoc:
+  Exclude:
+    - spec/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source 'https://rubygems.org'
+source "https://rubygems.org"
 gemspec
 
 gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 2.5.0"

--- a/jekyll-compose.gemspec
+++ b/jekyll-compose.gemspec
@@ -1,20 +1,20 @@
 # coding: utf-8
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'jekyll-compose/version'
+require "jekyll-compose/version"
 
 Gem::Specification.new do |spec|
   spec.name          = "jekyll-compose"
   spec.version       = Jekyll::Compose::VERSION
   spec.authors       = ["Parker Moore"]
   spec.email         = ["parkrmoore@gmail.com"]
-  spec.summary       = %q{Streamline your writing in Jekyll with these commands.}
-  spec.description   = %q{Streamline your writing in Jekyll with these commands.}
+  spec.summary       = "Streamline your writing in Jekyll with these commands."
+  spec.description   = "Streamline your writing in Jekyll with these commands."
   spec.homepage      = "https://github.com/jekyll/jekyll-compose"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").grep(%r{(bin|lib)/})
-  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.files         = `git ls-files -z`.split("\x0").grep(%r!(bin|lib)/!)
+  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_dependency "jekyll", ">= 3.0.0"

--- a/lib/jekyll-compose.rb
+++ b/lib/jekyll-compose.rb
@@ -7,9 +7,9 @@ require "jekyll-compose/file_info"
 
 module Jekyll
   module Compose
-    DEFAULT_TYPE = "md"
-    DEFAULT_LAYOUT = "post"
-    DEFAULT_LAYOUT_PAGE = "page"
+    DEFAULT_TYPE = "md".freeze
+    DEFAULT_LAYOUT = "post".freeze
+    DEFAULT_LAYOUT_PAGE = "page".freeze
   end
 end
 

--- a/lib/jekyll-compose/arg_parser.rb
+++ b/lib/jekyll-compose/arg_parser.rb
@@ -7,7 +7,7 @@ class Jekyll::Compose::ArgParser
   end
 
   def validate!
-    raise ArgumentError.new('You must specify a name.') if args.empty?
+    raise ArgumentError, "You must specify a name." if args.empty?
   end
 
   def type
@@ -19,7 +19,7 @@ class Jekyll::Compose::ArgParser
   end
 
   def title
-    args.join ' '
+    args.join " "
   end
 
   def force?
@@ -27,6 +27,6 @@ class Jekyll::Compose::ArgParser
   end
 
   def source
-    config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
+    config["source"].gsub(%r!^#{Regexp.quote(Dir.pwd)}!, "")
   end
 end

--- a/lib/jekyll-compose/file_creator.rb
+++ b/lib/jekyll-compose/file_creator.rb
@@ -17,7 +17,7 @@ module Jekyll
       private
 
       def validate_should_write!
-        raise ArgumentError.new("A #{file.resource_type} already exists at #{file_path}") if File.exist?(file_path) and !force
+        raise ArgumentError, "A #{file.resource_type} already exists at #{file_path}" if File.exist?(file_path) && !force
       end
 
       def ensure_directory_exists
@@ -34,7 +34,7 @@ module Jekyll
       end
 
       def file_path
-        return file.path if root.nil? or root.empty?
+        return file.path if root.nil? || root.empty?
         return File.join(root, file.path)
       end
     end

--- a/lib/jekyll-compose/file_info.rb
+++ b/lib/jekyll-compose/file_info.rb
@@ -11,8 +11,8 @@ class Jekyll::Compose::FileInfo
 
   def content
     front_matter = YAML.dump({
-      'layout' => params.layout,
-      'title' => params.title,
+      "layout" => params.layout,
+      "title"  => params.title,
     })
 
     front_matter + "---\n"

--- a/lib/jekyll-compose/file_mover.rb
+++ b/lib/jekyll-compose/file_mover.rb
@@ -8,7 +8,7 @@ module Jekyll
       end
 
       def resource_type
-        'file'
+        "file"
       end
 
       def move
@@ -18,7 +18,7 @@ module Jekyll
       end
 
       def validate_source
-        raise ArgumentError.new("There was no #{resource_type} found at '#{from}'.") unless File.exist? from
+        raise ArgumentError, "There was no #{resource_type} found at '#{from}'." unless File.exist? from
       end
 
       def ensure_directory_exists
@@ -41,7 +41,7 @@ module Jekyll
       end
 
       def file_path(path)
-        return path if root.nil? or root.empty?
+        return path if root.nil? || root.empty?
         return File.join(root, path)
       end
     end

--- a/lib/jekyll-compose/movement_arg_parser.rb
+++ b/lib/jekyll-compose/movement_arg_parser.rb
@@ -9,15 +9,15 @@ module Jekyll
       end
 
       def validate!
-        raise ArgumentError.new("You must specify a #{resource_type} path.") if args.empty?
+        raise ArgumentError, "You must specify a #{resource_type} path." if args.empty?
       end
 
       def path
-        args.join ' '
+        args.join " "
       end
 
       def source
-        source = config['source'].gsub(/^#{Regexp.quote(Dir.pwd)}/, '')
+        source = config["source"].gsub(%r!^#{Regexp.quote(Dir.pwd)}!, "")
       end
     end
   end

--- a/lib/jekyll-compose/version.rb
+++ b/lib/jekyll-compose/version.rb
@@ -1,5 +1,5 @@
 module Jekyll
   module Compose
-    VERSION = "0.5.0"
+    VERSION = "0.5.0".freeze
   end
 end

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -3,10 +3,10 @@ module Jekyll
     class Draft < Command
       def self.init_with_program(prog)
         prog.command(:draft) do |c|
-          c.syntax 'draft NAME'
-          c.description 'Creates a new draft post with the given NAME'
+          c.syntax "draft NAME"
+          c.description "Creates a new draft post with the given NAME"
 
-          options.each {|opt| c.option *opt }
+          options.each { |opt| c.option *opt }
 
           c.action { |args, options| process args, options }
         end
@@ -14,14 +14,13 @@ module Jekyll
 
       def self.options
         [
-          ['extension', '-x EXTENSION', '--extension EXTENSION', 'Specify the file extension'],
-          ['layout', '-l LAYOUT', '--layout LAYOUT', "Specify the draft layout"],
-          ['force', '-f', '--force', 'Overwrite a draft if it already exists'],
-          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'],
-          ['source', '-s', '--source SOURCE', 'Custom source directory'],
+          ["extension", "-x EXTENSION", "--extension EXTENSION", "Specify the file extension"],
+          ["layout", "-l LAYOUT", "--layout LAYOUT", "Specify the draft layout"],
+          ["force", "-f", "--force", "Overwrite a draft if it already exists"],
+          ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
+          ["source", "-s", "--source SOURCE", "Custom source directory"],
         ]
       end
-
 
       def self.process(args = [], options = {})
         params = Compose::ArgParser.new args, options
@@ -34,7 +33,7 @@ module Jekyll
 
       class DraftFileInfo < Compose::FileInfo
         def resource_type
-          'draft'
+          "draft"
         end
 
         def path

--- a/lib/jekyll/commands/page.rb
+++ b/lib/jekyll/commands/page.rb
@@ -3,10 +3,10 @@ module Jekyll
     class Page < Command
       def self.init_with_program(prog)
         prog.command(:page) do |c|
-          c.syntax 'page NAME'
-          c.description 'Creates a new page with the given NAME'
+          c.syntax "page NAME"
+          c.description "Creates a new page with the given NAME"
 
-          options.each {|opt| c.option *opt }
+          options.each { |opt| c.option *opt }
 
           c.action { |args, options| process args, options }
         end
@@ -14,11 +14,11 @@ module Jekyll
 
       def self.options
         [
-          ['extension', '-x EXTENSION', '--extension EXTENSION', 'Specify the file extension'],
-          ['layout', '-l LAYOUT', '--layout LAYOUT', "Specify the page layout"],
-          ['force', '-f', '--force', 'Overwrite a page if it already exists'],
-          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'],
-          ['source', '-s', '--source SOURCE', 'Custom source directory'],
+          ["extension", "-x EXTENSION", "--extension EXTENSION", "Specify the file extension"],
+          ["layout", "-l LAYOUT", "--layout LAYOUT", "Specify the page layout"],
+          ["force", "-f", "--force", "Overwrite a page if it already exists"],
+          ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
+          ["source", "-s", "--source SOURCE", "Custom source directory"],
         ]
       end
 
@@ -39,11 +39,10 @@ module Jekyll
 
       class PageFileInfo < Compose::FileInfo
         def resource_type
-          'page'
+          "page"
         end
 
         alias_method :path, :file_name
-
       end
     end
   end

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -3,10 +3,10 @@ module Jekyll
     class Post < Command
       def self.init_with_program(prog)
         prog.command(:post) do |c|
-          c.syntax 'post NAME'
-          c.description 'Creates a new post with the given NAME'
+          c.syntax "post NAME"
+          c.description "Creates a new post with the given NAME"
 
-          options.each {|opt| c.option *opt }
+          options.each { |opt| c.option *opt }
 
           c.action { |args, options| process args, options }
         end
@@ -14,12 +14,12 @@ module Jekyll
 
       def self.options
         [
-          ['extension', '-x EXTENSION', '--extension EXTENSION', 'Specify the file extension'],
-          ['layout', '-l LAYOUT', '--layout LAYOUT', "Specify the post layout"],
-          ['force', '-f', '--force', 'Overwrite a post if it already exists'],
-          ['date', '-d DATE', '--date DATE', 'Specify the post date'],
-          ['config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'],
-          ['source', '-s', '--source SOURCE', 'Custom source directory'],
+          ["extension", "-x EXTENSION", "--extension EXTENSION", "Specify the file extension"],
+          ["layout", "-l LAYOUT", "--layout LAYOUT", "Specify the post layout"],
+          ["force", "-f", "--force", "Overwrite a post if it already exists"],
+          ["date", "-d DATE", "--date DATE", "Specify the post date"],
+          ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
+          ["source", "-s", "--source SOURCE", "Custom source directory"],
         ]
       end
 
@@ -32,7 +32,6 @@ module Jekyll
         Compose::FileCreator.new(post, params.force?, params.source).create!
       end
 
-
       class PostArgParser < Compose::ArgParser
         def date
           options["date"].nil? ? Time.now : DateTime.parse(options["date"])
@@ -41,7 +40,7 @@ module Jekyll
 
       class PostFileInfo < Compose::FileInfo
         def resource_type
-          'post'
+          "post"
         end
 
         def path
@@ -53,7 +52,7 @@ module Jekyll
         end
 
         def _date_stamp
-          @params.date.strftime '%Y-%m-%d'
+          @params.date.strftime "%Y-%m-%d"
         end
       end
     end

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -3,12 +3,12 @@ module Jekyll
     class Publish < Command
       def self.init_with_program(prog)
         prog.command(:publish) do |c|
-          c.syntax 'publish DRAFT_PATH'
-          c.description 'Moves a draft into the _posts directory and sets the date'
+          c.syntax "publish DRAFT_PATH"
+          c.description "Moves a draft into the _posts directory and sets the date"
 
-          c.option 'date', '-d DATE', '--date DATE', 'Specify the post date'
-          c.option 'config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
-          c.option 'source', '-s', '--source SOURCE', 'Custom source directory'
+          c.option "date", "-d DATE", "--date DATE", "Specify the post date"
+          c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
+          c.option "source", "-s", "--source SOURCE", "Custom source directory"
 
           c.action do |args, options|
             Jekyll::Commands::Publish.process(args, options)
@@ -25,7 +25,6 @@ module Jekyll
         mover = DraftMover.new movement, params.source
         mover.move
       end
-
     end
 
     class PublishArgParser < Compose::MovementArgParser
@@ -53,14 +52,14 @@ module Jekyll
       end
 
       def to
-        date_stamp = params.date.strftime '%Y-%m-%d'
+        date_stamp = params.date.strftime "%Y-%m-%d"
         "_posts/#{date_stamp}-#{params.name}"
       end
     end
 
     class DraftMover < Compose::FileMover
       def resource_type
-        'draft'
+        "draft"
       end
     end
   end

--- a/lib/jekyll/commands/unpublish.rb
+++ b/lib/jekyll/commands/unpublish.rb
@@ -3,11 +3,11 @@ module Jekyll
     class Unpublish < Command
       def self.init_with_program(prog)
         prog.command(:unpublish) do |c|
-          c.syntax 'unpublish POST_PATH'
-          c.description 'Moves a post back into the _drafts directory'
+          c.syntax "unpublish POST_PATH"
+          c.description "Moves a post back into the _drafts directory"
 
-          c.option 'config', '--config CONFIG_FILE[,CONFIG_FILE2,...]', Array, 'Custom configuration file'
-          c.option 'source', '-s', '--source SOURCE', 'Custom source directory'
+          c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
+          c.option "source", "-s", "--source SOURCE", "Custom source directory"
 
           c.action do |args, options|
             process(args, options)
@@ -24,16 +24,15 @@ module Jekyll
         mover = PostMover.new movement, params.source
         mover.move
       end
-
     end
 
     class UnpublishArgParser < Compose::MovementArgParser
       def resource_type
-        'post'
+        "post"
       end
 
       def name
-        File.basename(path).sub /\d{4}-\d{2}-\d{2}-/, ''
+        File.basename(path).sub %r!\d{4}-\d{2}-\d{2}-!, ""
       end
     end
 
@@ -54,7 +53,7 @@ module Jekyll
 
     class PostMover < Compose::FileMover
       def resource_type
-        'post'
+        "post"
       end
     end
   end

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe(Jekyll::Commands::Draft) do
-  let(:name) { 'A test post' }
+  let(:name) { "A test post" }
   let(:args) { [name] }
-  let(:drafts_dir) { Pathname.new source_dir('_drafts') }
-  let(:path) { drafts_dir.join('a-test-post.md') }
+  let(:drafts_dir) { Pathname.new source_dir("_drafts") }
+  let(:path) { drafts_dir.join("a-test-post.md") }
 
   before(:all) do
     FileUtils.mkdir_p source_dir unless File.directory? source_dir
@@ -17,72 +17,72 @@ RSpec.describe(Jekyll::Commands::Draft) do
     FileUtils.rm_r drafts_dir if File.directory? drafts_dir
   end
 
-  it 'creates a new draft' do
+  it "creates a new draft" do
     expect(path).not_to exist
     capture_stdout { described_class.process(args) }
     expect(path).to exist
   end
 
-  it 'writes a helpful success message' do
+  it "writes a helpful success message" do
     output = capture_stdout { described_class.process(args) }
     expect(output).to eql("New draft created at _drafts/a-test-post.md.\n")
   end
 
-  it 'errors with no arguments' do
-    expect(-> {
+  it "errors with no arguments" do
+    expect(lambda {
       capture_stdout { described_class.process }
-    }).to raise_error('You must specify a name.')
+    }).to raise_error("You must specify a name.")
   end
 
-  it 'creates the drafts folder if necessary' do
+  it "creates the drafts folder if necessary" do
     FileUtils.rm_r drafts_dir if File.directory? drafts_dir
     capture_stdout { described_class.process(args) }
     expect(drafts_dir).to exist
   end
 
-  it 'creates the draft with a specified extension' do
-    html_path = drafts_dir.join 'a-test-post.html'
+  it "creates the draft with a specified extension" do
+    html_path = drafts_dir.join "a-test-post.html"
     expect(html_path).not_to exist
-    capture_stdout { described_class.process(args, 'extension' => 'html') }
+    capture_stdout { described_class.process(args, "extension" => "html") }
     expect(html_path).to exist
   end
 
-  it 'creates a new draft with the specified layout' do
-    capture_stdout { described_class.process(args, 'layout' => 'other-layout') }
-    expect(File.read(path)).to match(/layout: other-layout/)
+  it "creates a new draft with the specified layout" do
+    capture_stdout { described_class.process(args, "layout" => "other-layout") }
+    expect(File.read(path)).to match(%r!layout: other-layout!)
   end
 
-  context 'when the draft already exists' do
-    let(:name) { 'An existing draft' }
-    let(:path) { drafts_dir.join('an-existing-draft.md') }
+  context "when the draft already exists" do
+    let(:name) { "An existing draft" }
+    let(:path) { drafts_dir.join("an-existing-draft.md") }
 
     before(:each) do
       FileUtils.touch path
     end
 
-    it 'raises an error' do
-      expect(-> {
+    it "raises an error" do
+      expect(lambda {
         capture_stdout { described_class.process(args) }
       }).to raise_error("A draft already exists at _drafts/an-existing-draft.md")
     end
 
-    it 'overwrites if --force is given' do
-      expect(-> {
-        capture_stdout { described_class.process(args, 'force' => true) }
+    it "overwrites if --force is given" do
+      expect(lambda {
+        capture_stdout { described_class.process(args, "force" => true) }
       }).not_to raise_error
-      expect(File.read(path)).to match(/layout: post/)
+      expect(File.read(path)).to match(%r!layout: post!)
     end
   end
 
-  context 'when a configuration file exists' do
-    let(:config) { source_dir('_config.yml') }
-    let(:drafts_dir) { Pathname.new source_dir(File.join('site', '_drafts')) }
+  context "when a configuration file exists" do
+    let(:config) { source_dir("_config.yml") }
+    let(:drafts_dir) { Pathname.new source_dir(File.join("site", "_drafts")) }
 
     before(:each) do
-      File.open(config, 'w') do |f|
-        f.write(%{
+      File.open(config, "w") do |f|
+        f.write(%(
 source: site
-})
+))
       end
     end
 
@@ -90,19 +90,19 @@ source: site
       FileUtils.rm(config)
     end
 
-    it 'should use source directory set by config' do
+    it "should use source directory set by config" do
       expect(path).not_to exist
       capture_stdout { described_class.process(args) }
       expect(path).to exist
     end
   end
 
-  context 'when source option is set' do
-    let(:drafts_dir) { Pathname.new source_dir(File.join('site', '_drafts')) }
+  context "when source option is set" do
+    let(:drafts_dir) { Pathname.new source_dir(File.join("site", "_drafts")) }
 
-    it 'should use source directory set by command line option' do
+    it "should use source directory set by command line option" do
       expect(path).not_to exist
-      capture_stdout { described_class.process(args, 'source' => 'site') }
+      capture_stdout { described_class.process(args, "source" => "site") }
       expect(path).to exist
     end
   end

--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -1,46 +1,49 @@
 RSpec.describe(Jekyll::Compose::FileInfo) do
-  describe '#content' do
-    context 'with a title of only words' do
-      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
+  describe "#content" do
+    context "with a title of only words" do
+      let(:expected_result) do
+        <<-CONTENT.gsub(%r!^\s+!, "")
           ---
           layout: post
           title: A test arg parser
           ---
         CONTENT
-      }
+      end
 
-      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
-          ['A test arg parser'],
+      let(:parsed_args) do
+        Jekyll::Compose::ArgParser.new(
+          ["A test arg parser"],
           {}
         )
-      }
+      end
 
-      it 'does not wrap the title in quotes' do
+      it "does not wrap the title in quotes" do
         file_info = described_class.new parsed_args
         expect(file_info.content).to eq(expected_result)
       end
     end
 
-    context 'with a title that includes a colon' do
-      let(:expected_result) {<<-CONTENT.gsub(/^\s+/, '')
+    context "with a title that includes a colon" do
+      let(:expected_result) do
+        <<-CONTENT.gsub(%r!^\s+!, "")
           ---
           layout: post
           title: 'A test: arg parser'
           ---
         CONTENT
-      }
+      end
 
-      let(:parsed_args) { Jekyll::Compose::ArgParser.new(
-          ['A test: arg parser'],
+      let(:parsed_args) do
+        Jekyll::Compose::ArgParser.new(
+          ["A test: arg parser"],
           {}
         )
-      }
+      end
 
-      it 'does wrap the title in quotes' do
+      it "does wrap the title in quotes" do
         file_info = described_class.new parsed_args
         expect(file_info.content).to eq(expected_result)
       end
     end
   end
 end
-

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -1,5 +1,5 @@
 RSpec.describe(Jekyll::Commands::Page) do
-  let(:name) { 'A test page' }
+  let(:name) { "A test page" }
   let(:args) { [name] }
   let(:filename) { "a-test-page.md" }
   let(:path) { Pathname.new(source_dir).join(filename) }
@@ -13,66 +13,66 @@ RSpec.describe(Jekyll::Commands::Page) do
     FileUtils.rm path if File.exist? path
   end
 
-  it 'creates a new page' do
+  it "creates a new page" do
     expect(path).not_to exist
     capture_stdout { described_class.process(args) }
     expect(path).to exist
   end
 
-  it 'creates a new page with the specified extension' do
-    html_path = Pathname.new(source_dir).join 'a-test-page.html'
+  it "creates a new page with the specified extension" do
+    html_path = Pathname.new(source_dir).join "a-test-page.html"
     FileUtils.rm html_path if File.exist? html_path
-    capture_stdout { described_class.process(args, 'extension' => 'html') }
+    capture_stdout { described_class.process(args, "extension" => "html") }
     expect(html_path).to exist
   end
 
-  it 'creates a new page with the specified layout' do
-    capture_stdout { described_class.process(args, 'layout' => 'other-layout') }
-    expect(File.read(path)).to match(/layout: other-layout/)
+  it "creates a new page with the specified layout" do
+    capture_stdout { described_class.process(args, "layout" => "other-layout") }
+    expect(File.read(path)).to match(%r!layout: other-layout!)
   end
 
-  it 'should write a helpful message when successful' do
+  it "should write a helpful message when successful" do
     output = capture_stdout { described_class.process(args) }
     expect(output).to eql("New page created at #{filename}.\n")
   end
 
-  it 'errors with no arguments' do
-    expect(-> {
+  it "errors with no arguments" do
+    expect(lambda {
       capture_stdout { described_class.process }
-    }).to raise_error('You must specify a name.')
+    }).to raise_error("You must specify a name.")
   end
 
-  context 'when the page already exists' do
-    let(:name) { 'An existing page' }
+  context "when the page already exists" do
+    let(:name) { "An existing page" }
     let(:filename) { "an-existing-page.md" }
 
     before(:each) do
       FileUtils.touch path
     end
 
-    it 'raises an error' do
-      expect(-> {
+    it "raises an error" do
+      expect(lambda {
         capture_stdout { described_class.process(args) }
       }).to raise_error("A page already exists at #{filename}")
     end
 
-    it 'overwrites if --force is given' do
-      expect(-> {
-        capture_stdout { described_class.process(args, 'force' => true) }
+    it "overwrites if --force is given" do
+      expect(lambda {
+        capture_stdout { described_class.process(args, "force" => true) }
       }).not_to raise_error
-      expect(File.read(path)).to match(/layout: page/)
+      expect(File.read(path)).to match(%r!layout: page!)
     end
   end
 
-  context 'when a configuration file exists' do
-    let(:config) { source_dir('_config.yml') }
-    let(:path) { Pathname.new(source_dir).join('site', filename) }
+  context "when a configuration file exists" do
+    let(:config) { source_dir("_config.yml") }
+    let(:path) { Pathname.new(source_dir).join("site", filename) }
 
     before(:each) do
-      File.open(config, 'w') do |f|
-        f.write(%{
+      File.open(config, "w") do |f|
+        f.write(%(
 source: site
-})
+))
       end
     end
 
@@ -80,19 +80,19 @@ source: site
       FileUtils.rm(config)
     end
 
-    it 'should use source directory set by config' do
+    it "should use source directory set by config" do
       expect(path).not_to exist
       capture_stdout { described_class.process(args) }
       expect(path).to exist
     end
   end
 
-  context 'when source option is set' do
-    let(:path) { Pathname.new(source_dir).join('site', filename) }
+  context "when source option is set" do
+    let(:path) { Pathname.new(source_dir).join("site", filename) }
 
-    it 'should use source directory set by command line option' do
+    it "should use source directory set by command line option" do
       expect(path).not_to exist
-      capture_stdout { described_class.process(args, 'source' => 'site') }
+      capture_stdout { described_class.process(args, "source" => "site") }
       expect(path).to exist
     end
   end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe(Jekyll::Commands::Post) do
-  let(:name) { 'A test post' }
+  let(:name) { "A test post" }
   let(:args) { [name] }
-  let(:posts_dir) { Pathname.new source_dir('_posts') }
-  let(:datestamp) { Time.now.strftime('%Y-%m-%d') }
+  let(:posts_dir) { Pathname.new source_dir("_posts") }
+  let(:datestamp) { Time.now.strftime("%Y-%m-%d") }
   let(:filename) { "#{datestamp}-a-test-post.md" }
   let(:path) { posts_dir.join(filename) }
 
@@ -19,79 +19,79 @@ RSpec.describe(Jekyll::Commands::Post) do
     FileUtils.rm_r posts_dir if File.directory? posts_dir
   end
 
-  it 'creates a new post' do
+  it "creates a new post" do
     expect(path).not_to exist
     capture_stdout { described_class.process(args) }
     expect(path).to exist
   end
 
-  it 'creates a post with a specified date' do
-    path = posts_dir.join '2012-03-04-a-test-post.md'
+  it "creates a post with a specified date" do
+    path = posts_dir.join "2012-03-04-a-test-post.md"
     expect(path).not_to exist
-    capture_stdout { described_class.process(args, {"date" => '2012-3-4'}) }
+    capture_stdout { described_class.process(args, { "date" => "2012-3-4" }) }
     expect(path).to exist
   end
 
-  it 'creates the post with a specified extension' do
+  it "creates the post with a specified extension" do
     html_path = posts_dir.join "#{datestamp}-a-test-post.html"
     expect(html_path).not_to exist
-    capture_stdout { described_class.process(args, 'extension' => 'html') }
+    capture_stdout { described_class.process(args, "extension" => "html") }
     expect(html_path).to exist
   end
 
-  it 'creates a new post with the specified layout' do
-    capture_stdout { described_class.process(args, 'layout' => 'other-layout') }
-    expect(File.read(path)).to match(/layout: other-layout/)
+  it "creates a new post with the specified layout" do
+    capture_stdout { described_class.process(args, "layout" => "other-layout") }
+    expect(File.read(path)).to match(%r!layout: other-layout!)
   end
 
-  it 'should write a helpful message when successful' do
+  it "should write a helpful message when successful" do
     output = capture_stdout { described_class.process(args) }
     expect(output).to eql("New post created at _posts/#{filename}.\n")
   end
 
-  it 'errors with no arguments' do
-    expect(-> {
+  it "errors with no arguments" do
+    expect(lambda {
       capture_stdout { described_class.process }
-    }).to raise_error('You must specify a name.')
+    }).to raise_error("You must specify a name.")
   end
 
-  it 'creates the posts folder if necessary' do
+  it "creates the posts folder if necessary" do
     FileUtils.rm_r posts_dir if File.directory? posts_dir
     capture_stdout { described_class.process(args) }
     expect(posts_dir).to exist
   end
 
-  context 'when the post already exists' do
-    let(:name) { 'An existing post' }
-    let(:filename) { "#{Time.now.strftime('%Y-%m-%d')}-an-existing-post.md" }
+  context "when the post already exists" do
+    let(:name) { "An existing post" }
+    let(:filename) { "#{Time.now.strftime("%Y-%m-%d")}-an-existing-post.md" }
 
     before(:each) do
       FileUtils.touch path
     end
 
-    it 'raises an error' do
-      expect(-> {
+    it "raises an error" do
+      expect(lambda {
         capture_stdout { described_class.process(args) }
       }).to raise_error("A post already exists at _posts/#{filename}")
     end
 
-    it 'overwrites if --force is given' do
-      expect(-> {
-        capture_stdout { described_class.process(args, 'force' => true) }
+    it "overwrites if --force is given" do
+      expect(lambda {
+        capture_stdout { described_class.process(args, "force" => true) }
       }).not_to raise_error
-      expect(File.read(path)).to match(/layout: post/)
+      expect(File.read(path)).to match(%r!layout: post!)
     end
   end
 
-  context 'when a configuration file exists' do
-    let(:config) { source_dir('_config.yml') }
-    let(:posts_dir) { Pathname.new source_dir('site', '_posts') }
+  context "when a configuration file exists" do
+    let(:config) { source_dir("_config.yml") }
+    let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
 
     before(:each) do
-      File.open(config, 'w') do |f|
-        f.write(%{
+      File.open(config, "w") do |f|
+        f.write(%(
 source: site
-})
+))
       end
     end
 
@@ -99,19 +99,19 @@ source: site
       FileUtils.rm(config)
     end
 
-    it 'should use source directory set by config' do
+    it "should use source directory set by config" do
       expect(path).not_to exist
       capture_stdout { described_class.process(args) }
       expect(path).to exist
     end
   end
 
-  context 'when source option is set' do
-    let(:posts_dir) { Pathname.new source_dir('site', '_posts') }
+  context "when source option is set" do
+    let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
 
-    it 'should use source directory set by command line option' do
+    it "should use source directory set by command line option" do
       expect(path).not_to exist
-      capture_stdout { described_class.process(args, 'source' => 'site') }
+      capture_stdout { described_class.process(args, "source" => "site") }
       expect(path).to exist
     end
   end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -1,8 +1,8 @@
 RSpec.describe(Jekyll::Commands::Publish) do
-  let(:drafts_dir) { Pathname.new source_dir('_drafts') }
-  let(:posts_dir)  { Pathname.new source_dir('_posts') }
-  let(:draft_to_publish) { 'a-test-post.md' }
-  let(:datestamp) { Time.now.strftime('%Y-%m-%d') }
+  let(:drafts_dir) { Pathname.new source_dir("_drafts") }
+  let(:posts_dir)  { Pathname.new source_dir("_posts") }
+  let(:draft_to_publish) { "a-test-post.md" }
+  let(:datestamp) { Time.now.strftime("%Y-%m-%d") }
   let(:post_filename) { "#{datestamp}-#{draft_to_publish}" }
   let(:args) { ["_drafts/#{draft_to_publish}"] }
 
@@ -27,63 +27,63 @@ RSpec.describe(Jekyll::Commands::Publish) do
     FileUtils.rm_r post_path if File.file? post_path
   end
 
-  it 'publishes a draft post' do
+  it "publishes a draft post" do
     expect(post_path).not_to exist
     expect(draft_path).to exist
     capture_stdout { described_class.process(args) }
     expect(post_path).to exist
   end
 
-  it 'publishes with a specified date' do
+  it "publishes with a specified date" do
     path = posts_dir.join "2012-03-04-#{draft_to_publish}"
     expect(path).not_to exist
-    capture_stdout { described_class.process(args, {'date'=>'2012-3-4'}) }
+    capture_stdout { described_class.process(args, { "date"=>"2012-3-4" }) }
     expect(path).to exist
   end
 
-  it 'writes a helpful message on success' do
+  it "writes a helpful message on success" do
     expect(draft_path).to exist
     output = capture_stdout { described_class.process(args) }
     expect(output).to eql("Draft _drafts/#{draft_to_publish} was moved to _posts/#{post_filename}\n")
   end
 
-  it 'publishes a draft on the specified date' do
+  it "publishes a draft on the specified date" do
     path = posts_dir.join "2012-03-04-a-test-post.md"
-    capture_stdout { described_class.process(args, {"date" => '2012-3-4'}) }
+    capture_stdout { described_class.process(args, { "date" => "2012-3-4" }) }
     expect(path).to exist
   end
 
-  it 'creates the posts folder if necessary' do
+  it "creates the posts folder if necessary" do
     FileUtils.rm_r posts_dir if File.directory? posts_dir
     capture_stdout { described_class.process(args) }
     expect(posts_dir).to exist
   end
 
-  it 'errors if there is no argument' do
-    expect(-> {
+  it "errors if there is no argument" do
+    expect(lambda {
       capture_stdout { described_class.process }
-    }).to raise_error('You must specify a draft path.')
+    }).to raise_error("You must specify a draft path.")
   end
 
-  it 'errors if no file exists at given path' do
-    weird_path = '_drafts/i-do-not-exist.markdown'
-    expect(-> {
+  it "errors if no file exists at given path" do
+    weird_path = "_drafts/i-do-not-exist.markdown"
+    expect(lambda {
       capture_stdout { described_class.process [weird_path] }
     }).to raise_error("There was no draft found at '_drafts/i-do-not-exist.markdown'.")
   end
 
-  context 'when a configuration file exists' do
-    let(:config) { source_dir('_config.yml') }
-    let(:drafts_dir) { Pathname.new source_dir('site', '_drafts') }
-    let(:posts_dir)  { Pathname.new source_dir('site', '_posts') }
+  context "when a configuration file exists" do
+    let(:config) { source_dir("_config.yml") }
+    let(:drafts_dir) { Pathname.new source_dir("site", "_drafts") }
+    let(:posts_dir)  { Pathname.new source_dir("site", "_posts") }
 
     let(:args) { ["site/_drafts/#{draft_to_publish}"] }
 
     before(:each) do
-      File.open(config, 'w') do |f|
-        f.write(%{
+      File.open(config, "w") do |f|
+        f.write(%(
 source: site
-})
+))
       end
     end
 
@@ -91,7 +91,7 @@ source: site
       FileUtils.rm(config)
     end
 
-    it 'should use source directory set by config' do
+    it "should use source directory set by config" do
       expect(post_path).not_to exist
       expect(draft_path).to exist
       capture_stdout { described_class.process(args) }
@@ -99,16 +99,16 @@ source: site
     end
   end
 
-  context 'when source option is set' do
-    let(:drafts_dir) { Pathname.new source_dir('site', '_drafts') }
-    let(:posts_dir)  { Pathname.new source_dir('site', '_posts') }
+  context "when source option is set" do
+    let(:drafts_dir) { Pathname.new source_dir("site", "_drafts") }
+    let(:posts_dir)  { Pathname.new source_dir("site", "_posts") }
 
     let(:args) { ["site/_drafts/#{draft_to_publish}"] }
 
-    it 'should use source directory set by command line option' do
+    it "should use source directory set by command line option" do
       expect(post_path).not_to exist
       expect(draft_path).to exist
-      capture_stdout { described_class.process(args, 'source' => 'site') }
+      capture_stdout { described_class.process(args, "source" => "site") }
       expect(post_path).to exist
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,7 +17,7 @@ RSpec.configure do |config|
   config.warnings = true
 
   if config.files_to_run.one?
-    config.default_formatter = 'doc'
+    config.default_formatter = "doc"
   end
 
   config.profile_examples = 3
@@ -37,13 +37,13 @@ RSpec.configure do |config|
   end
 
   def source_dir(*files)
-    test_dir('source', *files)
+    test_dir("source", *files)
   end
 
   def fixture_site
     Jekyll::Site.new(Jekyll::Utils.deep_merge_hashes(
       Jekyll::Configuration::DEFAULTS,
-      { 'source' => source_dir, 'destination' => test_dir('dest') }
+      { "source" => source_dir, "destination" => test_dir("dest") }
     ))
   end
 

--- a/spec/unpublish_spec.rb
+++ b/spec/unpublish_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe(Jekyll::Commands::Unpublish) do
-  let(:drafts_dir) { Pathname.new(source_dir('_drafts')) }
-  let(:posts_dir)  { Pathname.new(source_dir('_posts')) }
+  let(:drafts_dir) { Pathname.new(source_dir("_drafts")) }
+  let(:posts_dir)  { Pathname.new(source_dir("_posts")) }
   let(:post_name) { "a-test-post.md" }
   let(:post_filename) { "2012-03-04-#{post_name}" }
   let(:post_path) { posts_dir.join post_filename }
@@ -24,7 +24,7 @@ RSpec.describe(Jekyll::Commands::Unpublish) do
     FileUtils.rm_r posts_dir if File.directory? posts_dir
   end
 
-  it 'moves a post back to _drafts' do
+  it "moves a post back to _drafts" do
     expect(post_path).to exist
     expect(draft_path).not_to exist
     capture_stdout { described_class.process(args) }
@@ -32,43 +32,43 @@ RSpec.describe(Jekyll::Commands::Unpublish) do
     expect(draft_path).to exist
   end
 
-  it 'writes a helpful message on success' do
+  it "writes a helpful message on success" do
     expect(post_path).to exist
     output = capture_stdout { described_class.process(args) }
     expect(output).to eql("Post _posts/#{post_filename} was moved to _drafts/#{post_name}\n")
   end
 
-  it 'creates the drafts folder if necessary' do
+  it "creates the drafts folder if necessary" do
     FileUtils.rm_r drafts_dir if File.directory? drafts_dir
     capture_stdout { described_class.process(args) }
     expect(drafts_dir).to exist
   end
 
-  it 'errors if there is no argument' do
-    expect(-> {
+  it "errors if there is no argument" do
+    expect(lambda {
       capture_stdout { described_class.process }
-    }).to raise_error('You must specify a post path.')
+    }).to raise_error("You must specify a post path.")
   end
 
-  it 'errors if no file exists at given path' do
-    weird_path = '_posts/i-forgot-the-date.md'
-    expect(-> {
+  it "errors if no file exists at given path" do
+    weird_path = "_posts/i-forgot-the-date.md"
+    expect(lambda {
       capture_stdout { described_class.process [weird_path] }
     }).to raise_error("There was no post found at '#{weird_path}'.")
   end
 
-  context 'when a configuration file exists' do
-    let(:config) { source_dir('_config.yml') }
-    let(:drafts_dir) { Pathname.new(source_dir('site', '_drafts')) }
-    let(:posts_dir)  { Pathname.new(source_dir('site', '_posts')) }
+  context "when a configuration file exists" do
+    let(:config) { source_dir("_config.yml") }
+    let(:drafts_dir) { Pathname.new(source_dir("site", "_drafts")) }
+    let(:posts_dir)  { Pathname.new(source_dir("site", "_posts")) }
 
     let(:args) { ["site/_posts/#{post_filename}"] }
 
     before(:each) do
-      File.open(config, 'w') do |f|
-        f.write(%{
+      File.open(config, "w") do |f|
+        f.write(%(
 source: site
-})
+))
       end
     end
 
@@ -76,7 +76,7 @@ source: site
       FileUtils.rm(config)
     end
 
-    it 'should use source directory set by config' do
+    it "should use source directory set by config" do
       expect(post_path).to exist
       expect(draft_path).not_to exist
       capture_stdout { described_class.process(args) }
@@ -85,16 +85,16 @@ source: site
     end
   end
 
-  context 'when source option is set' do
-    let(:drafts_dir) { Pathname.new(source_dir('site', '_drafts')) }
-    let(:posts_dir)  { Pathname.new(source_dir('site', '_posts')) }
+  context "when source option is set" do
+    let(:drafts_dir) { Pathname.new(source_dir("site", "_drafts")) }
+    let(:posts_dir)  { Pathname.new(source_dir("site", "_posts")) }
 
     let(:args) { ["site/_posts/#{post_filename}"] }
 
-    it 'should use source directory set by command line option' do
+    it "should use source directory set by command line option" do
       expect(post_path).to exist
       expect(draft_path).not_to exist
-      capture_stdout { described_class.process(args, 'source' => 'site') }
+      capture_stdout { described_class.process(args, "source" => "site") }
       expect(post_path).not_to exist
       expect(draft_path).to exist
     end


### PR DESCRIPTION
This PR is the result of adding `inherit_gem:\n jekyll: .rubocop.yml` to `.rubocop.yml` and running `rubocop -a` so that this project follows Jekyll core's coding styles for consistency like other core plugins. This way, as Jekyll's Ruby style changes, so too will this project's.