### PR TITLE
Add date to front matter when publish

### DIFF
--- a/lib/jekyll-compose/file_info.rb
+++ b/lib/jekyll-compose/file_info.rb
@@ -9,11 +9,11 @@ class Jekyll::Compose::FileInfo
     "#{name}.#{params.type}"
   end
 
-  def content
+  def content(custom_front_matter = {})
     front_matter = YAML.dump({
       "layout" => params.layout,
       "title"  => params.title,
-    })
+    }.merge(custom_front_matter))
 
     front_matter + "---\n"
   end

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -54,6 +54,14 @@ module Jekyll
         def _date_stamp
           @params.date.strftime "%Y-%m-%d"
         end
+
+        def _time_stamp
+          @params.date.strftime("%Y-%m-%d %H:%M %z")
+        end
+
+        def content(custom_front_matter = {})
+          super({ "date" => _time_stamp }.merge(custom_front_matter))
+        end
       end
     end
   end

--- a/spec/file_info_spec.rb
+++ b/spec/file_info_spec.rb
@@ -45,5 +45,29 @@ RSpec.describe(Jekyll::Compose::FileInfo) do
         expect(file_info.content).to eq(expected_result)
       end
     end
+
+    context "with custom values" do
+      let(:expected_result) do
+        <<-CONTENT.gsub(%r!^\s+!, "")
+          ---
+          layout: post
+          title: A test
+          foo: bar
+          ---
+        CONTENT
+      end
+
+      let(:parsed_args) do
+        Jekyll::Compose::ArgParser.new(
+          ["A test arg parser"],
+          {}
+        )
+      end
+
+      it "does not wrap the title in quotes" do
+        file_info = described_class.new parsed_args
+        expect(file_info.content("title" => "A test", "foo" => "bar")).to eq(expected_result)
+      end
+    end
   end
 end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -3,6 +3,7 @@ RSpec.describe(Jekyll::Commands::Post) do
   let(:args) { [name] }
   let(:posts_dir) { Pathname.new source_dir("_posts") }
   let(:datestamp) { Time.now.strftime("%Y-%m-%d") }
+  let(:timestamp) { Time.now.strftime("%Y-%m-%d %H:%M %z") }
   let(:filename) { "#{datestamp}-a-test-post.md" }
   let(:path) { posts_dir.join(filename) }
 
@@ -30,6 +31,7 @@ RSpec.describe(Jekyll::Commands::Post) do
     expect(path).not_to exist
     capture_stdout { described_class.process(args, { "date" => "2012-3-4" }) }
     expect(path).to exist
+    expect(File.read(path)).to match(%r!date: 2012-03-04 00:00 \+0000!)
   end
 
   it "creates the post with a specified extension" do


### PR DESCRIPTION
Based on @xianny work (https://github.com/jekyll/jekyll-compose/pull/43). Added specs and comments from original pull request applied.

Closes #43 