### PR TITLE
Check if a file should be overwritten when publishing or unpublishing a post

### DIFF
--- a/lib/jekyll-compose/file_mover.rb
+++ b/lib/jekyll-compose/file_mover.rb
@@ -3,24 +3,30 @@
 module Jekyll
   module Compose
     class FileMover
-      attr_reader :movement, :root
-      def initialize(movement, root = nil)
+      attr_reader :force, :movement, :root
+      def initialize(movement, force = false, root = nil)
         @movement = movement
+        @force = force
         @root = root
       end
 
-      def resource_type
+      def resource_type_from
+        "file"
+      end
+
+      def resource_type_to
         "file"
       end
 
       def move
         validate_source
+        validate_should_write!
         ensure_directory_exists
         move_file
       end
 
       def validate_source
-        raise ArgumentError, "There was no #{resource_type} found at '#{from}'." unless File.exist? from
+        raise ArgumentError, "There was no #{resource_type_from} found at '#{from}'." unless File.exist? from
       end
 
       def ensure_directory_exists
@@ -28,9 +34,13 @@ module Jekyll
         Dir.mkdir(dir) unless Dir.exist?(dir)
       end
 
+      def validate_should_write!
+        raise ArgumentError, "A #{resource_type_to} already exists at #{to}" if File.exist?(to) && !force
+      end
+
       def move_file
         FileUtils.mv(from, to)
-        puts "#{resource_type.capitalize} #{from} was moved to #{to}"
+        puts "#{resource_type_from.capitalize} #{from} was moved to #{to}"
       end
 
       private

--- a/lib/jekyll-compose/movement_arg_parser.rb
+++ b/lib/jekyll-compose/movement_arg_parser.rb
@@ -2,13 +2,7 @@
 
 module Jekyll
   module Compose
-    class MovementArgParser
-      attr_reader :args, :options, :config
-      def initialize(args, options)
-        @args = args
-        @options = options
-        @config = Jekyll.configuration(options)
-      end
+    class MovementArgParser < ArgParser
 
       def validate!
         raise ArgumentError, "You must specify a #{resource_type} path." if args.empty?
@@ -16,10 +10,6 @@ module Jekyll
 
       def path
         args.join " "
-      end
-
-      def source
-        config["source"].gsub(%r!^#{Regexp.quote(Dir.pwd)}!, "")
       end
     end
   end

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -10,6 +10,7 @@ module Jekyll
 
           c.option "date", "-d DATE", "--date DATE", "Specify the post date"
           c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
+          c.option "force", "-f", "--force", "Overwrite a post if it already exists"
           c.option "source", "-s", "--source SOURCE", "Custom source directory"
 
           c.action do |args, options|
@@ -24,7 +25,7 @@ module Jekyll
 
         movement = DraftMovementInfo.new params
 
-        mover = DraftMover.new movement, params.source
+        mover = DraftMover.new movement, params.force?, params.source
         mover.move
       end
     end
@@ -60,8 +61,11 @@ module Jekyll
     end
 
     class DraftMover < Compose::FileMover
-      def resource_type
+      def resource_type_from
         "draft"
+      end
+      def resource_type_to
+        "post"
       end
     end
   end

--- a/lib/jekyll/commands/unpublish.rb
+++ b/lib/jekyll/commands/unpublish.rb
@@ -9,6 +9,7 @@ module Jekyll
           c.description "Moves a post back into the _drafts directory"
 
           c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
+          c.option "force", "-f", "--force", "Overwrite a draft if it already exists"
           c.option "source", "-s", "--source SOURCE", "Custom source directory"
 
           c.action do |args, options|
@@ -23,7 +24,7 @@ module Jekyll
 
         movement = PostMovementInfo.new params
 
-        mover = PostMover.new movement, params.source
+        mover = PostMover.new movement, params.force?, params.source
         mover.move
       end
     end
@@ -54,8 +55,11 @@ module Jekyll
     end
 
     class PostMover < Compose::FileMover
-      def resource_type
+      def resource_type_from
         "post"
+      end
+      def resource_type_to
+        "draft"
       end
     end
   end

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -74,6 +74,30 @@ RSpec.describe(Jekyll::Commands::Publish) do
     }).to raise_error("There was no draft found at '_drafts/i-do-not-exist.markdown'.")
   end
 
+  context "when the post already exists" do
+    let(:args) { ["_drafts/#{draft_to_publish}"] }
+
+    before(:each) do
+      FileUtils.touch post_path
+    end
+
+    it "raises an error" do
+      expect(lambda {
+        capture_stdout { described_class.process(args) }
+      }).to raise_error("A post already exists at _posts/#{post_filename}")
+      expect(draft_path).to exist
+      expect(post_path).to exist
+    end
+
+    it "overwrites if --force is given" do
+      expect(lambda {
+        capture_stdout { described_class.process(args, "force" => true) }
+      }).not_to raise_error
+      expect(draft_path).not_to exist
+      expect(post_path).to exist
+    end
+  end
+
   context "when a configuration file exists" do
     let(:config) { source_dir("_config.yml") }
     let(:drafts_dir) { Pathname.new source_dir("site", "_drafts") }

--- a/spec/unpublish_spec.rb
+++ b/spec/unpublish_spec.rb
@@ -59,6 +59,30 @@ RSpec.describe(Jekyll::Commands::Unpublish) do
     }).to raise_error("There was no post found at '#{weird_path}'.")
   end
 
+  context "when the draft already exists" do
+    let(:args) { ["_posts/#{post_filename}"] }
+
+    before(:each) do
+      FileUtils.touch draft_path
+    end
+
+    it "raises an error" do
+      expect(lambda {
+        capture_stdout { described_class.process(args) }
+      }).to raise_error("A draft already exists at _drafts/#{post_name}")
+      expect(draft_path).to exist
+      expect(post_path).to exist
+    end
+
+    it "overwrites if --force is given" do
+      expect(lambda {
+        capture_stdout { described_class.process(args, "force" => true) }
+      }).not_to raise_error
+      expect(draft_path).to exist
+      expect(post_path).not_to exist
+    end
+  end
+
   context "when a configuration file exists" do
     let(:config) { source_dir("_config.yml") }
     let(:drafts_dir) { Pathname.new(source_dir("site", "_drafts")) }


### PR DESCRIPTION
The `post` command checks for overwriting files before creating a new post, and allows overwriting an existing post with `--force`.

Change `publish` and `unpublish` to behave the same way as `post`.

Had to teach `FileMover` about `force` and the `resource_type` had to be split into `from` and `to` for the error messages to be correct.

Also, `MovementArgParser` was modified to validate the force flag I think. I simplified it as there was some duplicate code with `ArgParser`. However I'd be happy to change this back and duplicate the code for force, especially if the change to `MovementArgParser` has some other side effects I haven't found yet.