### PR TITLE
Formatting of dates and times in a DRY manner

### DIFF
--- a/lib/jekyll-compose.rb
+++ b/lib/jekyll-compose.rb
@@ -12,6 +12,8 @@ module Jekyll
     DEFAULT_TYPE = "md".freeze
     DEFAULT_LAYOUT = "post".freeze
     DEFAULT_LAYOUT_PAGE = "page".freeze
+    DEFAULT_DATESTAMP_FORMAT = "%Y-%m-%d".freeze
+    DEFAULT_TIMESTAMP_FORMAT = "%Y-%m-%d %H:%M %z".freeze
   end
 end
 

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -54,11 +54,11 @@ module Jekyll
         end
 
         def _date_stamp
-          @params.date.strftime "%Y-%m-%d"
+          @params.date.strftime Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT
         end
 
         def _time_stamp
-          @params.date.strftime("%Y-%m-%d %H:%M %z")
+          @params.date.strftime Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT
         end
 
         def content(custom_front_matter = {})

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -54,7 +54,7 @@ module Jekyll
       end
 
       def to
-        date_stamp = params.date.strftime "%Y-%m-%d"
+        date_stamp = params.date.strftime Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT
         "_posts/#{date_stamp}-#{params.name}"
       end
     end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe(Jekyll::Commands::Post) do
   let(:name) { "A test post" }
   let(:args) { [name] }
   let(:posts_dir) { Pathname.new source_dir("_posts") }
-  let(:datestamp) { Time.now.strftime("%Y-%m-%d") }
-  let(:timestamp) { Time.now.strftime("%Y-%m-%d %H:%M %z") }
+  let(:datestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT) }
+  let(:timestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
   let(:filename) { "#{datestamp}-a-test-post.md" }
   let(:path) { posts_dir.join(filename) }
 
@@ -67,7 +67,7 @@ RSpec.describe(Jekyll::Commands::Post) do
 
   context "when the post already exists" do
     let(:name) { "An existing post" }
-    let(:filename) { "#{Time.now.strftime("%Y-%m-%d")}-an-existing-post.md" }
+    let(:filename) { "#{Time.now.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT)}-an-existing-post.md" }
 
     before(:each) do
       FileUtils.touch path

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe(Jekyll::Commands::Publish) do
   let(:drafts_dir) { Pathname.new source_dir("_drafts") }
   let(:posts_dir)  { Pathname.new source_dir("_posts") }
   let(:draft_to_publish) { "a-test-post.md" }
-  let(:datestamp) { Time.now.strftime("%Y-%m-%d") }
+  let(:datestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT) }
   let(:post_filename) { "#{datestamp}-#{draft_to_publish}" }
   let(:args) { ["_drafts/#{draft_to_publish}"] }
 


### PR DESCRIPTION
May make it easier to make changes to the format, i.e: to match the default format suggested

"YYYY-MM-DD HH:MM:SS +/-TTTT" as from https://jekyllrb.com/docs/frontmatter/

or to make these configurable values.