### PR TITLE
Auto open newly generated files in selected editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ Unpublish your post using:
 
     $ bundle exec jekyll unpublish _posts/2014-01-24-my-new-draft.md
 
+## Configuration
+
+To customize the default plugin configuration edit the `jekyll_compose` section within your jekyll config file.
+
+```
+  jekyll_compose:
+    auto_open: true
+```
+
+and make sure that you have `EDITOR` or `JEKYLL_EDITOR` environment variable set.
+
+The latter one will override default `EDITOR` value.
+
+It will open a newly generated post in your selected editor.
+
 ## Contributing
 
 1. Fork it ( http://github.com/jekyll/jekyll-compose/fork )

--- a/lib/jekyll-compose.rb
+++ b/lib/jekyll-compose.rb
@@ -6,6 +6,7 @@ require "jekyll-compose/movement_arg_parser"
 require "jekyll-compose/file_creator"
 require "jekyll-compose/file_mover"
 require "jekyll-compose/file_info"
+require "jekyll-compose/file_editor"
 
 module Jekyll
   module Compose

--- a/lib/jekyll-compose/file_creator.rb
+++ b/lib/jekyll-compose/file_creator.rb
@@ -16,6 +16,11 @@ module Jekyll
         write_file
       end
 
+      def file_path
+        return file.path if root.nil? || root.empty?
+        return File.join(root, file.path)
+      end
+
       private
 
       def validate_should_write!
@@ -33,11 +38,6 @@ module Jekyll
         end
 
         puts "New #{file.resource_type} created at #{file_path}."
-      end
-
-      def file_path
-        return file.path if root.nil? || root.empty?
-        return File.join(root, file.path)
       end
     end
   end

--- a/lib/jekyll-compose/file_editor.rb
+++ b/lib/jekyll-compose/file_editor.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+#
+# This class is aimed to open the created file in the selected editor.
+# To use this feature specify at Jekyll config:
+#
+# ```
+#  jekyll_compose:
+#    auto_open: true
+# ```
+#
+# And make sure, that you have JEKYLL_EDITOR or EDITOR environment variables set up.
+# This will allow to open the file in your default editor automatically.
+
+module Jekyll
+  module Compose
+    class FileEditor
+      class << self
+        def open_editor(filepath)
+          run_editor(post_editor, File.expand_path(filepath)) if post_editor
+        end
+
+        def run_editor(editor_name, filepath)
+          system("#{editor_name} #{filepath}")
+        end
+
+        def post_editor
+          return unless auto_open?
+          ENV['JEKYLL_EDITOR'] || ENV['EDITOR']
+        end
+
+        def auto_open?
+          jekyll_compose_config && jekyll_compose_config['auto_open']
+        end
+
+        def jekyll_compose_config
+          @jekyll_compose_config ||= Jekyll.configuration['jekyll_compose']
+        end
+      end
+    end
+  end
+end
+

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -31,7 +31,9 @@ module Jekyll
 
         post = PostFileInfo.new params
 
-        Compose::FileCreator.new(post, params.force?, params.source).create!
+        file_creator = Compose::FileCreator.new(post, params.force?, params.source)
+        file_creator.create!
+        Compose::FileEditor.open_editor(file_creator.file_path)
       end
 
       class PostArgParser < Compose::ArgParser

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe(Jekyll::Commands::Post) do
 
   before(:each) do
     FileUtils.mkdir_p posts_dir unless File.directory? posts_dir
+    allow(Jekyll::Compose::FileEditor).to receive(:system)
   end
 
   after(:each) do
@@ -90,12 +91,13 @@ RSpec.describe(Jekyll::Commands::Post) do
   context "when a configuration file exists" do
     let(:config) { source_dir("_config.yml") }
     let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
+    let(:config_data) { %(
+source: site
+) }
 
     before(:each) do
       File.open(config, "w") do |f|
-        f.write(%(
-source: site
-))
+        f.write(config_data)
       end
     end
 
@@ -107,6 +109,32 @@ source: site
       expect(path).not_to exist
       capture_stdout { described_class.process(args) }
       expect(path).to exist
+    end
+
+    context 'auto_open editor is set' do
+      let(:posts_dir) { Pathname.new source_dir("_posts") }
+      let(:config_data) { %(
+jekyll_compose:
+  auto_open: true
+)}
+
+      context 'env variable EDITOR is set up' do
+        before { ENV['EDITOR'] = 'vim' }
+
+        it 'opens post in default editor' do
+          expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with('vim', path.to_s)
+          capture_stdout { described_class.process(args) }
+        end
+
+        context 'env variable JEKYLL_EDITOR is set up' do
+          before { ENV['JEKYLL_EDITOR'] = 'nano' }
+
+          it 'opens post in jekyll editor' do
+            expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with('nano', path.to_s)
+            capture_stdout { described_class.process(args) }
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Every time when I generate a new post by `jekyll-compose` I need to find the new file in my editor, or copy-paste its path to open it.

Probably we can follow [migration_opener](https://github.com/evrone/migration_opener) approach and open file in selected editor automatically.