### PR TITLE
Rubocop 0.55

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_gem:
   jekyll: .rubocop.yml
 AllCops:
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.3
   Exclude:
     - vendor/**/*
 

--- a/jekyll-compose.gemspec
+++ b/jekyll-compose.gemspec
@@ -24,5 +24,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.5"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop", "~> 0.51"
+  spec.add_development_dependency "rubocop", "~> 0.55"
 end

--- a/lib/jekyll-compose.rb
+++ b/lib/jekyll-compose.rb
@@ -10,9 +10,9 @@ require "jekyll-compose/file_editor"
 
 module Jekyll
   module Compose
-    DEFAULT_TYPE = "md".freeze
-    DEFAULT_LAYOUT = "post".freeze
-    DEFAULT_LAYOUT_PAGE = "page".freeze
+    DEFAULT_TYPE = "md"
+    DEFAULT_LAYOUT = "post"
+    DEFAULT_LAYOUT_PAGE = "page"
   end
 end
 

--- a/lib/jekyll-compose/file_editor.rb
+++ b/lib/jekyll-compose/file_editor.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 #
 # This class is aimed to open the created file in the selected editor.
 # To use this feature specify at Jekyll config:
@@ -25,18 +26,17 @@ module Jekyll
 
         def post_editor
           return unless auto_open?
-          ENV['JEKYLL_EDITOR'] || ENV['EDITOR']
+          ENV["JEKYLL_EDITOR"] || ENV["EDITOR"]
         end
 
         def auto_open?
-          jekyll_compose_config && jekyll_compose_config['auto_open']
+          jekyll_compose_config && jekyll_compose_config["auto_open"]
         end
 
         def jekyll_compose_config
-          @jekyll_compose_config ||= Jekyll.configuration['jekyll_compose']
+          @jekyll_compose_config ||= Jekyll.configuration["jekyll_compose"]
         end
       end
     end
   end
 end
-

--- a/lib/jekyll-compose/movement_arg_parser.rb
+++ b/lib/jekyll-compose/movement_arg_parser.rb
@@ -3,7 +3,6 @@
 module Jekyll
   module Compose
     class MovementArgParser < ArgParser
-
       def validate!
         raise ArgumentError, "You must specify a #{resource_type} path." if args.empty?
       end

--- a/lib/jekyll-compose/version.rb
+++ b/lib/jekyll-compose/version.rb
@@ -2,6 +2,6 @@
 
 module Jekyll
   module Compose
-    VERSION = "0.8.0".freeze
+    VERSION = "0.8.0"
   end
 end

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -64,6 +64,7 @@ module Jekyll
       def resource_type_from
         "draft"
       end
+
       def resource_type_to
         "post"
       end

--- a/lib/jekyll/commands/unpublish.rb
+++ b/lib/jekyll/commands/unpublish.rb
@@ -58,6 +58,7 @@ module Jekyll
       def resource_type_from
         "post"
       end
+
       def resource_type_to
         "draft"
       end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -91,9 +91,11 @@ RSpec.describe(Jekyll::Commands::Post) do
   context "when a configuration file exists" do
     let(:config) { source_dir("_config.yml") }
     let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
-    let(:config_data) { %(
-source: site
-) }
+    let(:config_data) do
+      %(
+    source: site
+    )
+    end
 
     before(:each) do
       File.open(config, "w") do |f|
@@ -111,26 +113,28 @@ source: site
       expect(path).to exist
     end
 
-    context 'auto_open editor is set' do
+    context "auto_open editor is set" do
       let(:posts_dir) { Pathname.new source_dir("_posts") }
-      let(:config_data) { %(
-jekyll_compose:
-  auto_open: true
-)}
+      let(:config_data) do
+        %(
+      jekyll_compose:
+        auto_open: true
+      )
+      end
 
-      context 'env variable EDITOR is set up' do
-        before { ENV['EDITOR'] = 'vim' }
+      context "env variable EDITOR is set up" do
+        before { ENV["EDITOR"] = "vim" }
 
-        it 'opens post in default editor' do
-          expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with('vim', path.to_s)
+        it "opens post in default editor" do
+          expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("vim", path.to_s)
           capture_stdout { described_class.process(args) }
         end
 
-        context 'env variable JEKYLL_EDITOR is set up' do
-          before { ENV['JEKYLL_EDITOR'] = 'nano' }
+        context "env variable JEKYLL_EDITOR is set up" do
+          before { ENV["JEKYLL_EDITOR"] = "nano" }
 
-          it 'opens post in jekyll editor' do
-            expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with('nano', path.to_s)
+          it "opens post in jekyll editor" do
+            expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
             capture_stdout { described_class.process(args) }
           end
         end


### PR DESCRIPTION
- [x] Fix tests when using `Jekyll.logger.info`