### PR TITLE
Replace `puts` calls with `Jekyll.logger.info`

### DIFF
--- a/lib/jekyll-compose/file_creator.rb
+++ b/lib/jekyll-compose/file_creator.rb
@@ -37,7 +37,7 @@ module Jekyll
           f.puts(file.content)
         end
 
-        puts "New #{file.resource_type} created at #{file_path}."
+        Jekyll.logger.info "New #{file.resource_type} created at #{file_path}."
       end
     end
   end

--- a/lib/jekyll-compose/file_mover.rb
+++ b/lib/jekyll-compose/file_mover.rb
@@ -40,7 +40,7 @@ module Jekyll
 
       def move_file
         FileUtils.mv(from, to)
-        puts "#{resource_type_from.capitalize} #{from} was moved to #{to}"
+        Jekyll.logger.info "#{resource_type_from.capitalize} #{from} was moved to #{to}"
       end
 
       private

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe(Jekyll::Commands::Draft) do
 
   it "writes a helpful success message" do
     output = capture_stdout { described_class.process(args) }
-    expect(output).to eql("New draft created at _drafts/a-test-post.md.\n")
+    expect(output).to include("New draft created at _drafts/a-test-post.md.")
   end
 
   it "errors with no arguments" do

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe(Jekyll::Commands::Page) do
 
   it "should write a helpful message when successful" do
     output = capture_stdout { described_class.process(args) }
-    expect(output).to eql("New page created at #{filename}.\n")
+    expect(output).to include("New page created at #{filename}.")
   end
 
   it "errors with no arguments" do

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe(Jekyll::Commands::Post) do
 
   it "should write a helpful message when successful" do
     output = capture_stdout { described_class.process(args) }
-    expect(output).to eql("New post created at _posts/#{filename}.\n")
+    expect(output).to include("New post created at _posts/#{filename}.")
   end
 
   it "errors with no arguments" do

--- a/spec/publish_spec.rb
+++ b/spec/publish_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe(Jekyll::Commands::Publish) do
   it "writes a helpful message on success" do
     expect(draft_path).to exist
     output = capture_stdout { described_class.process(args) }
-    expect(output).to eql("Draft _drafts/#{draft_to_publish} was moved to _posts/#{post_filename}\n")
+    expect(output).to include("Draft _drafts/#{draft_to_publish} was moved to _posts/#{post_filename}")
   end
 
   it "publishes a draft on the specified date" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -49,13 +49,14 @@ RSpec.configure do |config|
     ))
   end
 
-  def capture_stdout
-    $old_stdout = $stdout
-    $stdout = StringIO.new
+  def capture_stdout(level = :debug)
+    buffer = StringIO.new
+    Jekyll.logger = Logger.new(buffer)
+    Jekyll.logger.log_level = level
     yield
-    $stdout.rewind
-    return $stdout.string
+    buffer.rewind
+    buffer.string.to_s
   ensure
-    $stdout = $old_stdout
+    Jekyll.logger = Logger.new(StringIO.new, :error)
   end
 end

--- a/spec/unpublish_spec.rb
+++ b/spec/unpublish_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe(Jekyll::Commands::Unpublish) do
   it "writes a helpful message on success" do
     expect(post_path).to exist
     output = capture_stdout { described_class.process(args) }
-    expect(output).to eql("Post _posts/#{post_filename} was moved to _drafts/#{post_name}\n")
+    expect(output).to include("Post _posts/#{post_filename} was moved to _drafts/#{post_name}")
   end
 
   it "creates the drafts folder if necessary" do


### PR DESCRIPTION
(Other Rubocop failures, if any, will be handled by #68)