### PR TITLE
Add some color to the success msg like jekyll new

### DIFF
--- a/lib/jekyll-compose/file_creator.rb
+++ b/lib/jekyll-compose/file_creator.rb
@@ -37,7 +37,7 @@ module Jekyll
           f.puts(file.content)
         end
 
-        Jekyll.logger.info "New #{file.resource_type} created at #{file_path}."
+        Jekyll.logger.info "New #{file.resource_type} created at #{file_path.cyan}"
       end
     end
   end

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe(Jekyll::Commands::Draft) do
 
   it "writes a helpful success message" do
     output = capture_stdout { described_class.process(args) }
-    expect(output).to include("New draft created at _drafts/a-test-post.md.")
+    expect(output).to include("New draft created at #{"_drafts/a-test-post.md".cyan}")
   end
 
   it "errors with no arguments" do

--- a/spec/page_spec.rb
+++ b/spec/page_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe(Jekyll::Commands::Page) do
 
   it "should write a helpful message when successful" do
     output = capture_stdout { described_class.process(args) }
-    expect(output).to include("New page created at #{filename}.")
+    expect(output).to include("New page created at #{filename.cyan}")
   end
 
   it "errors with no arguments" do

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe(Jekyll::Commands::Post) do
 
   it "should write a helpful message when successful" do
     output = capture_stdout { described_class.process(args) }
-    expect(output).to include("New post created at _posts/#{filename}.")
+    expect(output).to include("New post created at #{File.join("_posts", filename).cyan}")
   end
 
   it "errors with no arguments" do


### PR DESCRIPTION
Mirroring the success message from `jekyll new` command to reduce visual noise.
I also removed the full-stop at the end to further reduce noise with short extensions e.g. **` at new-page.md.`**