### PR TITLE
Generate configuration from CLI options

### DIFF
--- a/lib/jekyll-compose/arg_parser.rb
+++ b/lib/jekyll-compose/arg_parser.rb
@@ -4,10 +4,12 @@ module Jekyll
   module Compose
     class ArgParser
       attr_reader :args, :options, :config
-      def initialize(args, options)
+
+      # TODO: Remove `nil` parameter in v1.0
+      def initialize(args, options, config = nil)
         @args = args
         @options = options
-        @config = Jekyll.configuration(options)
+        @config = config || Jekyll.configuration(options)
       end
 
       def validate!

--- a/lib/jekyll-compose/file_editor.rb
+++ b/lib/jekyll-compose/file_editor.rb
@@ -16,6 +16,13 @@ module Jekyll
   module Compose
     class FileEditor
       class << self
+        attr_reader  :compose_config
+        alias_method :jekyll_compose_config, :compose_config
+
+        def bootstrap(config)
+          @compose_config = config["jekyll_compose"] || {}
+        end
+
         def open_editor(filepath)
           run_editor(post_editor, File.expand_path(filepath)) if post_editor
         end
@@ -30,11 +37,7 @@ module Jekyll
         end
 
         def auto_open?
-          jekyll_compose_config && jekyll_compose_config["auto_open"]
-        end
-
-        def jekyll_compose_config
-          @jekyll_compose_config ||= Jekyll.configuration["jekyll_compose"]
+          compose_config["auto_open"]
         end
       end
     end

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -25,7 +25,8 @@ module Jekyll
       end
 
       def self.process(args = [], options = {})
-        params = Compose::ArgParser.new args, options
+        config = configuration_from_options(options)
+        params = Compose::ArgParser.new args, options, config
         params.validate!
 
         draft = DraftFileInfo.new params

--- a/lib/jekyll/commands/page.rb
+++ b/lib/jekyll/commands/page.rb
@@ -25,7 +25,8 @@ module Jekyll
       end
 
       def self.process(args = [], options = {})
-        params = PageArgParser.new args, options
+        config = configuration_from_options(options)
+        params = PageArgParser.new args, options, config
         params.validate!
 
         page = PageFileInfo.new params

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -67,16 +67,10 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          default_front_matter = compose_config["post_default_front_matter"]
+          default_front_matter = params.config.dig("jekyll_compose", "post_default_front_matter")
           custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super({ "date" => _time_stamp }.merge(custom_front_matter))
-        end
-
-        private
-
-        def compose_config
-          @compose_config ||= Jekyll.configuration["jekyll_compose"] || {}
         end
       end
     end

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -26,13 +26,16 @@ module Jekyll
       end
 
       def self.process(args = [], options = {})
-        params = PostArgParser.new args, options
+        config = configuration_from_options(options)
+        params = PostArgParser.new args, options, config
         params.validate!
 
         post = PostFileInfo.new params
 
         file_creator = Compose::FileCreator.new(post, params.force?, params.source)
         file_creator.create!
+
+        Compose::FileEditor.bootstrap(config)
         Compose::FileEditor.open_editor(file_creator.file_path)
       end
 

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -20,7 +20,8 @@ module Jekyll
       end
 
       def self.process(args = [], options = {})
-        params = PublishArgParser.new args, options
+        config = configuration_from_options(options)
+        params = PublishArgParser.new args, options, config
         params.validate!
 
         movement = DraftMovementInfo.new params

--- a/lib/jekyll/commands/unpublish.rb
+++ b/lib/jekyll/commands/unpublish.rb
@@ -19,7 +19,8 @@ module Jekyll
       end
 
       def self.process(args = [], options = {})
-        params = UnpublishArgParser.new args, options
+        config = configuration_from_options(options)
+        params = UnpublishArgParser.new args, options, config
         params.validate!
 
         movement = PostMovementInfo.new params


### PR DESCRIPTION
## Summary

* Every call to `Jekyll.configuration` outputs a `Configuration file: [file_path]` to the terminal. So, its better to generate the `config` hash from cli options once and pass that hash to subsequent steps
* Initialize `Compose::ArgParser` subclasses with both `cli options` and the `generated config` to keep the two concerns separate and avoid clobbering.

Resolves #73 