### PR TITLE
Mirror `draft` command to current `post` command

### DIFF
--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -30,7 +30,9 @@ module Jekyll
 
         draft = DraftFileInfo.new params
 
-        Compose::FileCreator.new(draft, params.force?, params.source).create!
+        file_creator = Compose::FileCreator.new(draft, params.force?, params.source)
+        file_creator.create!
+        Compose::FileEditor.open_editor(file_creator.file_path)
       end
 
       class DraftFileInfo < Compose::FileInfo
@@ -40,6 +42,19 @@ module Jekyll
 
         def path
           "_drafts/#{file_name}"
+        end
+
+        def content(custom_front_matter = {})
+          default_front_matter = compose_config["draft_default_front_matter"]
+          custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
+
+          super(custom_front_matter)
+        end
+
+        private
+
+        def compose_config
+          @compose_config ||= Jekyll.configuration["jekyll_compose"] || {}
         end
       end
     end

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -133,10 +133,10 @@ RSpec.describe(Jekyll::Commands::Post) do
       end
 
       context "env variable EDITOR is set up" do
-        before { ENV["EDITOR"] = "vim" }
+        before { ENV["EDITOR"] = "nano" }
 
         it "opens post in default editor" do
-          expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("vim", path.to_s)
+          expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
           capture_stdout { described_class.process(args) }
         end
 


### PR DESCRIPTION
Adds two features to `draft` command:
  - Define front matter defaults for new drafts using `jekyll_compose.draft_default_front_matter` in `_config.yml`
  - Open new draft in editor based on `EDITOR`  OR `JEKYLL_EDITOR` ENV vars