### PR TITLE
Drop support for Ruby 2.3

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,3 +4,6 @@ require: rubocop-jekyll
 
 inherit_gem:
   rubocop-jekyll: .rubocop.yml
+
+AllCops:
+  TargetRubyVersion: 2.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-- 2.5
-- 2.3
+- 2.6
+- 2.4
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@
 source "https://rubygems.org"
 gemspec
 
-gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 2.5.0"
+gem "jekyll", ENV["JEKYLL_VERSION"] ? "~> #{ENV["JEKYLL_VERSION"]}" : ">= 3.0"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,6 @@ environment:
     - RUBY_FOLDER_VER: "25-x64"
     - RUBY_FOLDER_VER: "25"
     - RUBY_FOLDER_VER: "24"
-    - RUBY_FOLDER_VER: "23"
 
 install:
   - SET PATH=C:\Ruby%RUBY_FOLDER_VER%\bin;%PATH%

--- a/jekyll-compose.gemspec
+++ b/jekyll-compose.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.3.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.add_dependency "jekyll", "~> 3.0"
 
-  spec.add_development_dependency "bundler", "~> 1.5"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
-  spec.add_development_dependency "rubocop-jekyll", "~> 0.4"
+  spec.add_development_dependency "rubocop-jekyll", "~> 0.5"
 end


### PR DESCRIPTION
Targeting Ruby 2.4 does not change anything to the current codebase.