### PR TITLE
Re-introduce Ruby 2.3 support and test Jekyll 3.7+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,4 +6,4 @@ inherit_gem:
   rubocop-jekyll: .rubocop.yml
 
 AllCops:
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: ruby
 cache: bundler
 rvm:
-- 2.6
-- 2.4
+  - &latest_ruby 2.6
+  - 2.4
+  - 2.3
 
 before_install:
 - gem update --system
@@ -13,7 +14,15 @@ script: script/cibuild
 
 env:
   global:
-  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+  matrix:
+    - JEKYLL_VERSION="~> 3.8"
+matrix:
+  include:
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION="~> 3.7.4"
+    - rvm: *latest_ruby
+      env: JEKYLL_VERSION=">= 4.0.0.pre.alpha1"
 
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,13 +7,18 @@ branches:
 build: off
 
 environment:
+  JEKYLL_VERSION: "~> 3.8"
   matrix:
-    - RUBY_FOLDER_VER: "25-x64"
-    - RUBY_FOLDER_VER: "25"
+    - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : "~> 3.7.4"
+    - RUBY_FOLDER_VER: "26"
+      JEKYLL_VERSION : ">= 4.0.0.pre.alpha1"
+    - RUBY_FOLDER_VER: "26"
     - RUBY_FOLDER_VER: "24"
+    - RUBY_FOLDER_VER: "23"
 
 install:
-  - SET PATH=C:\Ruby%RUBY_FOLDER_VER%\bin;%PATH%
+  - SET PATH=C:\Ruby%RUBY_FOLDER_VER%-x64\bin;%PATH%
   - bundle install --retry 5 --jobs=%NUMBER_OF_PROCESSORS% --clean --path vendor\bundle
 
 test_script:

--- a/jekyll-compose.gemspec
+++ b/jekyll-compose.gemspec
@@ -14,11 +14,10 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/jekyll/jekyll-compose"
   spec.license       = "MIT"
 
-  spec.files         = `git ls-files -z`.split("\x0").grep(%r!(bin|lib)/!)
-  spec.executables   = spec.files.grep(%r!^bin/!) { |f| File.basename(f) }
+  spec.files         = `git ls-files -z`.split("\x0").grep(%r!^lib/!)
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4.0"
+  spec.required_ruby_version = ">= 2.3.0"
 
   spec.add_dependency "jekyll", ">= 3.7", "< 5.0"
 


### PR DESCRIPTION
The plugin doesn't use Ruby 2.4 specific syntax and therefore we can relax the Ruby version constraint to the minimum testable Ruby version across the ecosystem: Ruby 2.3

Other changes:
  - Remove superfluous entries from the gemspec
  - Test with Jekyll 4.0 pre-release