### PR TITLE
fix: can't use jekyll-compose's commands in Integrated terminal after auto open

### DIFF
--- a/lib/jekyll-compose/file_editor.rb
+++ b/lib/jekyll-compose/file_editor.rb
@@ -28,6 +28,7 @@ module Jekyll
         end
 
         def run_editor(editor_name, filepath)
+          ENV["JEKYLL_NO_BUNDLER_REQUIRE"] = nil
           system("#{editor_name} #{filepath}")
         end
 


### PR DESCRIPTION
Add a line to unset JEKYLL_NO_BUNDLER_REQUIRE before starting a editor.