### PR TITLE
Removing source option for commands as it is appearing twice.

### DIFF
--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -20,7 +20,6 @@ module Jekyll
           ["layout", "-l LAYOUT", "--layout LAYOUT", "Specify the draft layout"],
           ["force", "-f", "--force", "Overwrite a draft if it already exists"],
           ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
-          ["source", "-s", "--source SOURCE", "Custom source directory"],
         ]
       end
 

--- a/lib/jekyll/commands/page.rb
+++ b/lib/jekyll/commands/page.rb
@@ -20,7 +20,6 @@ module Jekyll
           ["layout", "-l LAYOUT", "--layout LAYOUT", "Specify the page layout"],
           ["force", "-f", "--force", "Overwrite a page if it already exists"],
           ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
-          ["source", "-s", "--source SOURCE", "Custom source directory"],
         ]
       end
 

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -21,7 +21,6 @@ module Jekyll
           ["force", "-f", "--force", "Overwrite a post if it already exists"],
           ["date", "-d DATE", "--date DATE", "Specify the post date"],
           ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
-          ["source", "-s", "--source SOURCE", "Custom source directory"],
         ]
       end
 

--- a/lib/jekyll/commands/publish.rb
+++ b/lib/jekyll/commands/publish.rb
@@ -11,7 +11,6 @@ module Jekyll
           c.option "date", "-d DATE", "--date DATE", "Specify the post date"
           c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
           c.option "force", "-f", "--force", "Overwrite a post if it already exists"
-          c.option "source", "-s", "--source SOURCE", "Custom source directory"
 
           c.action do |args, options|
             Jekyll::Commands::Publish.process(args, options)

--- a/lib/jekyll/commands/unpublish.rb
+++ b/lib/jekyll/commands/unpublish.rb
@@ -10,7 +10,6 @@ module Jekyll
 
           c.option "config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"
           c.option "force", "-f", "--force", "Overwrite a draft if it already exists"
-          c.option "source", "-s", "--source SOURCE", "Custom source directory"
 
           c.action do |args, options|
             process(args, options)


### PR DESCRIPTION
`jekyll post --help` shows both:

 -s, --source SOURCE  Custom source directory
 -s, --source [DIR]  Source directory (defaults to ./)