### PR TITLE
Add rename command to change titles and filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Listed in help you will see new commands available to you:
   publish    # Moves a draft into the _posts directory and sets the date
   unpublish  # Moves a post back into the _drafts directory
   page       # Creates a new page with the given NAME
+  rename     # Moves a draft to a given NAME and sets the title
 ```
 
 Create your new page using:
@@ -44,11 +45,38 @@ Create your new draft using:
 
     $ bundle exec jekyll draft "My new draft"
 
+Rename your draft using:
+
+```sh
+    $ bundle exec jekyll rename _drafts/my-new-draft.md "My Renamed Draft"
+```
+
+```sh
+    # or rename it back
+    $ bundle exec jekyll rename _drafts/my-renamed-draft.md "My new draft"
+```
+
 Publish your draft using:
 
     $ bundle exec jekyll publish _drafts/my-new-draft.md
     # or specify a specific date on which to publish it
     $ bundle exec jekyll publish _drafts/my-new-draft.md --date 2014-01-24
+
+Rename your post using:
+
+```sh
+    $ bundle exec jekyll rename _posts/2014-01-24-my-new-draft.md "My New Post"
+```
+
+```sh
+    # or specify a specific date
+    $ bundle exec jekyll rename _posts/2014-01-24-my-new-post.md "My Old Post" --date "2012-03-04"
+```
+
+```sh
+    # or specify the current date
+    $ bundle exec jekyll rename _posts/2012-03-04-my-old-post.md "My New Post" --now
+```
 
 Unpublish your post using:
 

--- a/README.md
+++ b/README.md
@@ -48,12 +48,12 @@ Create your new draft using:
 Rename your draft using:
 
 ```sh
-    $ bundle exec jekyll rename _drafts/my-new-draft.md "My Renamed Draft"
+$ bundle exec jekyll rename _drafts/my-new-draft.md "My Renamed Draft"
 ```
 
 ```sh
-    # or rename it back
-    $ bundle exec jekyll rename _drafts/my-renamed-draft.md "My new draft"
+# or rename it back
+$ bundle exec jekyll rename _drafts/my-renamed-draft.md "My new draft"
 ```
 
 Publish your draft using:
@@ -65,17 +65,17 @@ Publish your draft using:
 Rename your post using:
 
 ```sh
-    $ bundle exec jekyll rename _posts/2014-01-24-my-new-draft.md "My New Post"
+$ bundle exec jekyll rename _posts/2014-01-24-my-new-draft.md "My New Post"
 ```
 
 ```sh
-    # or specify a specific date
-    $ bundle exec jekyll rename _posts/2014-01-24-my-new-post.md "My Old Post" --date "2012-03-04"
+# or specify a specific date
+$ bundle exec jekyll rename _posts/2014-01-24-my-new-post.md "My Old Post" --date "2012-03-04"
 ```
 
 ```sh
-    # or specify the current date
-    $ bundle exec jekyll rename _posts/2012-03-04-my-old-post.md "My New Post" --now
+# or specify the current date
+$ bundle exec jekyll rename _posts/2012-03-04-my-old-post.md "My New Post" --now
 ```
 
 Unpublish your post using:

--- a/lib/jekyll-compose.rb
+++ b/lib/jekyll-compose.rb
@@ -18,6 +18,6 @@ module Jekyll
   end
 end
 
-%w(draft post publish unpublish page).each do |file|
+%w(draft post publish unpublish page rename).each do |file|
   require File.expand_path("jekyll/commands/#{file}.rb", __dir__)
 end

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Commands
+    class Rename < Command
+      def self.init_with_program(prog)
+        prog.command(:rename) do |c|
+          c.syntax "rename PATH NAME"
+          c.description "Moves a file to a given NAME and sets the title and date"
+
+          options.each { |opt| c.option(*opt) }
+
+          c.action { |args, options| process(args, options) }
+        end
+      end
+
+      def self.options
+        [
+          ["force", "-f", "--force", "Overwrite a post if it already exists"],
+          ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
+          ["date", "-d DATE", "--date DATE", "Specify the date"],
+          ["now", "--now", "Specify the date as now"],
+        ]
+      end
+
+      def self.process(args = [], options = {})
+        config = configuration_from_options(options)
+        params = RenameArgParser.new(args, options, config)
+        params.validate!
+
+        movement = RenameMovementInfo.new(params)
+
+        mover = RenameMover.new(movement, params.force?, params.source)
+        mover.move
+      end
+    end
+
+    class RenameArgParser < Compose::ArgParser
+      def validate!
+        raise ArgumentError, "You must specify a path." if args.empty?
+        raise ArgumentError, "You must specify a title." if args.length < 2
+        if options.values_at("date", "now").compact.length > 1
+          raise ArgumentError, "You can only specify one of --date DATE or --now."
+        end
+      end
+
+      def path
+        File.join(source, args[0]).sub(%r!\A/!, "") if args[0]
+      end
+
+      def dirname
+        File.dirname(args[0]) if args[0]
+      end
+
+      def basename
+        File.basename(args[0]) if args[0]
+      end
+
+      def title
+        args.drop(1).join(" ")
+      end
+
+      def name
+        if basename =~ Jekyll::Document::DATE_FILENAME_MATCHER
+          _, filename, fileext = Regexp.last_match.captures
+          "#{filename}#{fileext}"
+        else
+          basename
+        end
+      end
+
+      def touch?
+        !!options["date"] || options["now"]
+      end
+
+      def date
+        if options["now"]
+          @date = Time.now
+        else
+          @date ||= options["date"] ? Date.parse(options["date"]) : nil
+        end
+      end
+
+      def date_from_filename
+        if basename =~ Jekyll::Document::DATE_FILENAME_MATCHER
+          filedate, = Regexp.last_match.captures
+          Date.parse(filedate)
+        end
+      end
+
+      def post?
+        dirname == "_posts" if dirname
+      end
+
+      def draft?
+        dirname == "_drafts" if dirname
+      end
+    end
+
+    class RenameMovementInfo < Compose::FileInfo
+      attr_reader :params
+      def initialize(params)
+        @params = params
+      end
+
+      def from
+        params.path
+      end
+
+      def resource_type
+        if @params.post?
+          "post"
+        elsif @params.draft?
+          "draft"
+        else
+          "file"
+        end
+      end
+
+      def to
+        if @params.post?
+          File.join(@params.dirname, "#{_date_stamp}-#{file_name}")
+        else
+          File.join(@params.dirname, file_name)
+        end
+      end
+
+      def _date_stamp
+        if @params.touch?
+          @params.date.strftime Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT
+        else
+          @params.date_from_filename.strftime Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT
+        end
+      end
+
+      def _time_stamp
+        @params.date.strftime Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT
+      end
+
+      def front_matter(data)
+        data["title"] = params.title
+        data["date"] = _time_stamp if @params.touch?
+        data
+      end
+    end
+
+    class RenameMover < Compose::FileMover
+      def resource_type_from
+        @movement.resource_type
+      end
+
+      def resource_type_to
+        @movement.resource_type
+      end
+    end
+  end
+end

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -76,11 +76,11 @@ module Jekyll
       end
 
       def date
-        if options["now"]
-          @date = Time.now
-        else
-          @date ||= options["date"] ? Date.parse(options["date"]) : nil
-        end
+        @date ||= if options["now"]
+                    Time.now
+                  elsif options["date"]
+                    Date.parse(options["date"])
+                  end
       end
 
       def date_from_filename

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -62,15 +62,6 @@ module Jekyll
         args.drop(1).join(" ")
       end
 
-      def name
-        if basename =~ Jekyll::Document::DATE_FILENAME_MATCHER
-          _, filename, fileext = Regexp.last_match.captures
-          "#{filename}#{fileext}"
-        else
-          basename
-        end
-      end
-
       def touch?
         !!options["date"] || options["now"]
       end
@@ -85,8 +76,7 @@ module Jekyll
 
       def date_from_filename
         if basename =~ Jekyll::Document::DATE_FILENAME_MATCHER
-          filedate, = Regexp.last_match.captures
-          Date.parse(filedate)
+          Date.parse(Regexp.last_match(1))
         end
       end
 

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -37,8 +37,10 @@ module Jekyll
 
     class RenameArgParser < Compose::ArgParser
       def validate!
-        raise ArgumentError, "You must specify a path." if args.empty?
-        raise ArgumentError, "You must specify a title." if args.length < 2
+        if args.length < 2
+          raise ArgumentError, "You must specify current path and the new title."
+        end
+
         if options.values_at("date", "now").compact.length > 1
           raise ArgumentError, "You can only specify one of --date DATE or --now."
         end

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -47,15 +47,15 @@ module Jekyll
       end
 
       def path
-        File.join(source, args[0]).sub(%r!\A/!, "") if args[0]
+        File.join(source, args[0]).sub(%r!\A/!, "")
       end
 
       def dirname
-        File.dirname(args[0]) if args[0]
+        @dirname ||= File.dirname(args[0])
       end
 
       def basename
-        File.basename(args[0]) if args[0]
+        @basename ||= File.basename(args[0])
       end
 
       def title
@@ -91,11 +91,11 @@ module Jekyll
       end
 
       def post?
-        dirname == "_posts" if dirname
+        dirname == "_posts"
       end
 
       def draft?
-        dirname == "_drafts" if dirname
+        dirname == "_drafts"
       end
     end
 

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -46,20 +46,24 @@ module Jekyll
         end
       end
 
+      def current_path
+        @current_path ||= args[0]
+      end
+
       def path
-        File.join(source, args[0]).sub(%r!\A/!, "")
+        File.join(source, current_path).sub(%r!\A/!, "")
       end
 
       def dirname
-        @dirname ||= File.dirname(args[0])
+        @dirname ||= File.dirname(current_path)
       end
 
       def basename
-        @basename ||= File.basename(args[0])
+        @basename ||= File.basename(current_path)
       end
 
       def title
-        args.drop(1).join(" ")
+        @title ||= args.drop(1).join(" ")
       end
 
       def touch?

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -37,9 +37,7 @@ module Jekyll
 
     class RenameArgParser < Compose::ArgParser
       def validate!
-        if args.length < 2
-          raise ArgumentError, "You must specify current path and the new title."
-        end
+        raise ArgumentError, "You must specify current path and the new title." if args.length < 2
 
         if options.values_at("date", "now").compact.length > 1
           raise ArgumentError, "You can only specify one of --date DATE or --now."
@@ -79,9 +77,7 @@ module Jekyll
       end
 
       def date_from_filename
-        if basename =~ Jekyll::Document::DATE_FILENAME_MATCHER
-          Date.parse(Regexp.last_match(1))
-        end
+        Date.parse(Regexp.last_match(1)) if basename =~ Jekyll::Document::DATE_FILENAME_MATCHER
       end
 
       def post?

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -146,10 +146,7 @@ module Jekyll
       def resource_type_from
         @movement.resource_type
       end
-
-      def resource_type_to
-        @movement.resource_type
-      end
+      alias_method :resource_type_to, :resource_type_from
     end
   end
 end

--- a/lib/jekyll/commands/rename.rb
+++ b/lib/jekyll/commands/rename.rb
@@ -111,13 +111,21 @@ module Jekyll
 
       def to
         if @params.post?
-          File.join(@params.dirname, "#{_date_stamp}-#{file_name}")
+          File.join(@params.dirname, "#{date_stamp}-#{file_name}")
         else
           File.join(@params.dirname, file_name)
         end
       end
 
-      def _date_stamp
+      def front_matter(data)
+        data["title"] = params.title
+        data["date"] = time_stamp if @params.touch?
+        data
+      end
+
+      private
+
+      def date_stamp
         if @params.touch?
           @params.date.strftime Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT
         else
@@ -125,14 +133,8 @@ module Jekyll
         end
       end
 
-      def _time_stamp
+      def time_stamp
         @params.date.strftime Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT
-      end
-
-      def front_matter(data)
-        data["title"] = params.title
-        data["date"] = _time_stamp if @params.touch?
-        data
       end
     end
 

--- a/spec/rename_spec.rb
+++ b/spec/rename_spec.rb
@@ -58,13 +58,13 @@ RSpec.describe(Jekyll::Commands::Rename) do
     it "errors with no arguments" do
       expect(lambda {
         capture_stdout { described_class.process }
-      }).to raise_error("You must specify a path.")
+      }).to raise_error("You must specify current path and the new title.")
     end
 
     it "errors with only one argument" do
       expect(lambda {
         capture_stdout { described_class.process([old_path]) }
-      }).to raise_error("You must specify a title.")
+      }).to raise_error("You must specify current path and the new title.")
     end
 
     context "when the draft with the new filename already exists" do
@@ -209,13 +209,13 @@ RSpec.describe(Jekyll::Commands::Rename) do
     it "errors with no arguments" do
       expect(lambda {
         capture_stdout { described_class.process }
-      }).to raise_error("You must specify a path.")
+      }).to raise_error("You must specify current path and the new title.")
     end
 
     it "errors with only one argument" do
       expect(lambda {
         capture_stdout { described_class.process([old_path]) }
-      }).to raise_error("You must specify a title.")
+      }).to raise_error("You must specify current path and the new title.")
     end
 
     context "with a date argument" do

--- a/spec/rename_spec.rb
+++ b/spec/rename_spec.rb
@@ -1,0 +1,400 @@
+# frozen_string_literal: true
+
+RSpec.describe(Jekyll::Commands::Rename) do
+  let(:datestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT) }
+  let(:timestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
+
+  context "drafts" do
+    let(:drafts_dir) { Pathname.new source_dir("_drafts") }
+    let(:old_name) { "Old Draft" }
+    let(:new_name) { "New Draft" }
+    let(:old_filename) { "old-draft.md" }
+    let(:new_filename) { "new-draft.md" }
+    let(:old_path) { drafts_dir.join(old_filename) }
+    let(:new_path) { drafts_dir.join(new_filename) }
+    let(:old_arg) { File.join("_drafts", old_filename) }
+    let(:new_arg) { File.join("_drafts", new_filename) }
+    let(:args) { [old_arg, new_name] }
+
+    before(:all) do
+      FileUtils.mkdir_p source_dir unless File.directory? source_dir
+      Dir.chdir source_dir
+    end
+
+    before(:each) do
+      FileUtils.mkdir_p drafts_dir unless File.directory? drafts_dir
+      File.write(old_path, "---\nlayout: post\ntitle: Old Draft\n---\n")
+    end
+
+    after(:each) do
+      FileUtils.rm_r old_path if File.file? old_path
+      FileUtils.rm_r new_path if File.file? new_path
+      FileUtils.rm_r drafts_dir if File.directory? drafts_dir
+    end
+
+    it "moves a draft" do
+      expect(old_path).to exist
+      expect(new_path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(old_path).not_to exist
+      expect(new_path).to exist
+    end
+
+    it "changes the title of the draft" do
+      expect(old_path).to exist
+      expect(new_path).not_to exist
+      expect(File.read(old_path)).to match(%r!title: Old Draft!)
+      capture_stdout { described_class.process(args) }
+      expect(old_path).not_to exist
+      expect(new_path).to exist
+      expect(File.read(new_path)).to match(%r!title: New Draft!)
+    end
+
+    it "should write a helpful message when successful" do
+      output = capture_stdout { described_class.process(args) }
+      expect(output).to include("Draft #{old_arg} was moved to #{new_arg}")
+    end
+
+    it "errors with no arguments" do
+      expect(lambda {
+        capture_stdout { described_class.process }
+      }).to raise_error("You must specify a path.")
+    end
+
+    it "errors with only one argument" do
+      expect(lambda {
+        capture_stdout { described_class.process([old_path]) }
+      }).to raise_error("You must specify a title.")
+    end
+
+    context "when the draft with the new filename already exists" do
+      before(:each) do
+        FileUtils.touch new_path
+      end
+
+      it "displays a warning and returns" do
+        output = capture_stdout { described_class.process(args) }
+        expect(output).to include("A draft already exists at #{new_arg}")
+        expect(output).to_not include("Draft #{old_arg} was moved to #{new_arg}")
+        expect(File.read(new_path)).to_not include("layout: post")
+      end
+
+      it "overwrites if --force is given" do
+        output = capture_stdout { described_class.process(args, "force" => true) }
+        expect(output).to_not include("A draft already exists at #{new_arg}")
+        expect(output).to include("Draft #{old_arg} was moved to #{new_arg}")
+        expect(File.read(new_path)).to include("layout: post")
+      end
+    end
+
+    context "when a configuration file exists" do
+      let(:config) { source_dir("_config.yml") }
+      let(:drafts_dir) { Pathname.new source_dir("site", "_drafts") }
+      let(:config_data) do
+        %(
+      source: site
+      )
+      end
+
+      before(:each) do
+        File.open(config, "w") do |f|
+          f.write(config_data)
+        end
+      end
+
+      after(:each) do
+        FileUtils.rm(config)
+      end
+
+      it "should use source directory set by config" do
+        expect(new_path).not_to exist
+        capture_stdout { described_class.process(args) }
+        expect(new_path).to exist
+      end
+
+      context "and collections_dir is set" do
+        let(:collections_dir) { "my_collections" }
+        let(:drafts_dir) { Pathname.new source_dir("site", collections_dir, "_drafts") }
+        let(:config_data) do
+          %(
+        source: site
+        collections_dir: #{collections_dir}
+        )
+        end
+
+        it "should create drafts at the correct location" do
+          expect(drafts_dir).to exist
+          expect(old_path).to exist
+          expect(new_path).not_to exist
+          capture_stdout { described_class.process(args) }
+          expect(drafts_dir).to exist
+          expect(old_path).not_to exist
+          expect(new_path).to exist
+        end
+
+        it "should write a helpful message when successful" do
+          output = capture_stdout { described_class.process(args) }
+          old_arg = File.join("site", collections_dir, "_drafts", old_filename)
+          new_arg = File.join("site", collections_dir, "_drafts", new_filename)
+          expect(output).to include("Draft #{old_arg} was moved to #{new_arg}")
+        end
+      end
+    end
+
+    context "when source option is set" do
+      let(:drafts_dir) { Pathname.new source_dir("site", "_drafts") }
+
+      it "should use source directory set by command line option" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        capture_stdout { described_class.process(args, "source" => "site") }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+      end
+    end
+  end
+  context "posts" do
+    let(:posts_dir) { Pathname.new source_dir("_posts") }
+    let(:old_name) { "Old Post" }
+    let(:new_name) { "New Post" }
+    let(:old_basename) { "old-post.md" }
+    let(:new_basename) { "new-post.md" }
+    let(:old_filename) { "#{datestamp}-#{old_basename}" }
+    let(:new_filename) { "#{datestamp}-#{new_basename}" }
+    let(:old_path) { posts_dir.join(old_filename) }
+    let(:new_path) { posts_dir.join(new_filename) }
+    let(:old_arg) { File.join("_posts", old_filename) }
+    let(:new_arg) { File.join("_posts", new_filename) }
+    let(:args) { [old_arg, new_name] }
+
+    before(:all) do
+      FileUtils.mkdir_p source_dir unless File.directory? source_dir
+      Dir.chdir source_dir
+    end
+
+    before(:each) do
+      FileUtils.mkdir_p posts_dir unless File.directory? posts_dir
+      File.write(old_path, "---\nlayout: post\ntitle: #{old_name}\ndate: #{timestamp}\n---\n")
+    end
+
+    after(:each) do
+      FileUtils.rm_r old_path if File.file? old_path
+      FileUtils.rm_r new_path if File.file? new_path
+      FileUtils.rm_r posts_dir if File.directory? posts_dir
+    end
+
+    it "moves a post" do
+      expect(old_path).to exist
+      expect(new_path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(old_path).not_to exist
+      expect(new_path).to exist
+    end
+
+    it "changes the title of the post" do
+      expect(old_path).to exist
+      expect(new_path).not_to exist
+      expect(File.read(old_path)).to match(%r!title: #{old_name}!)
+      capture_stdout { described_class.process(args) }
+      expect(old_path).not_to exist
+      expect(new_path).to exist
+      expect(File.read(new_path)).to match(%r!title: #{new_name}!)
+    end
+
+    it "should write a helpful message when successful" do
+      output = capture_stdout { described_class.process(args) }
+      expect(output).to include("Post #{old_arg} was moved to #{new_arg}")
+    end
+
+    it "errors with no arguments" do
+      expect(lambda {
+        capture_stdout { described_class.process }
+      }).to raise_error("You must specify a path.")
+    end
+
+    it "errors with only one argument" do
+      expect(lambda {
+        capture_stdout { described_class.process([old_path]) }
+      }).to raise_error("You must specify a title.")
+    end
+
+    context "with a date argument" do
+      let(:new_datestamp) { "2012-03-04" }
+      let(:new_filename) { "#{new_datestamp}-#{new_basename}" }
+
+      it "moves a post" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        capture_stdout { described_class.process(args, "date" => new_datestamp) }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+      end
+
+      it "changes the title of the post" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        expect(File.read(old_path)).to match(%r!title: #{old_name}!)
+        capture_stdout { described_class.process(args, "date" => new_datestamp) }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+        expect(File.read(new_path)).to match(%r!title: #{new_name}!)
+      end
+
+      it "changes the date of the post" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        expect(File.read(old_path)).to match(%r!title: #{old_name}!)
+        capture_stdout { described_class.process(args, "date" => new_datestamp) }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+        expect(File.read(new_path)).to match(%r!date: #{new_datestamp}!)
+      end
+
+      it "should write a helpful message when successful" do
+        output = capture_stdout { described_class.process(args, "date" => new_datestamp) }
+        expect(output).to include("Post #{old_arg} was moved to #{new_arg}")
+      end
+    end
+
+    context "with a now argument" do
+      let(:now) { Time.parse("2015-06-07 08:09") }
+      let(:old) { Time.parse("2012-03-04 05:06") }
+      let(:now_datestamp) { now.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT) }
+      let(:now_timestamp) { now.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
+      let(:datestamp) { old.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT) }
+      let(:timestamp) { old.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
+      let(:new_filename) { "#{now_datestamp}-#{new_basename}" }
+
+      before(:each) do
+        FileUtils.mkdir_p posts_dir unless File.directory? posts_dir
+        File.write(old_path, "---\nlayout: post\ntitle: #{old_name}\ndate: #{timestamp}\n---\n")
+        allow(Time).to receive(:now).and_return(now)
+      end
+
+      after(:each) do
+        FileUtils.rm_r old_path if File.file? old_path
+        FileUtils.rm_r new_path if File.file? new_path
+        FileUtils.rm_r posts_dir if File.directory? posts_dir
+      end
+
+      it "moves a post" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        capture_stdout { described_class.process(args, "now" => true) }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+      end
+
+      it "changes the title of the post" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        expect(File.read(old_path)).to match(%r!title: #{old_name}!)
+        capture_stdout { described_class.process(args, "now" => true) }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+        expect(File.read(new_path)).to match(%r!title: #{new_name}!)
+      end
+
+      it "changes the date of the post" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        expect(File.read(old_path)).to match(%r!title: #{old_name}!)
+        capture_stdout { described_class.process(args, "now" => true) }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+        expect(File.read(new_path)).to match(%r!date: #{Regexp.quote(now_timestamp)}!)
+      end
+
+      it "should write a helpful message when successful" do
+        output = capture_stdout { described_class.process(args, "now" => true) }
+        expect(output).to include("Post #{old_arg} was moved to #{new_arg}")
+      end
+    end
+
+    context "when the post with the new filename already exists" do
+      before(:each) do
+        FileUtils.touch new_path
+      end
+
+      it "displays a warning and returns" do
+        output = capture_stdout { described_class.process(args) }
+        expect(output).to include("A post already exists at #{new_arg}")
+        expect(output).to_not include("Post #{old_arg} was moved to #{new_arg}")
+        expect(File.read(new_path)).to_not include("layout: post")
+      end
+
+      it "overwrites if --force is given" do
+        output = capture_stdout { described_class.process(args, "force" => true) }
+        expect(output).to_not include("A post already exists at #{new_arg}")
+        expect(output).to include("Post #{old_arg} was moved to #{new_arg}")
+        expect(File.read(new_path)).to include("layout: post")
+      end
+    end
+
+    context "when a configuration file exists" do
+      let(:config) { source_dir("_config.yml") }
+      let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
+      let(:config_data) do
+        %(
+      source: site
+      )
+      end
+
+      before(:each) do
+        File.open(config, "w") do |f|
+          f.write(config_data)
+        end
+      end
+
+      after(:each) do
+        FileUtils.rm(config)
+      end
+
+      it "should use source directory set by config" do
+        expect(new_path).not_to exist
+        capture_stdout { described_class.process(args) }
+        expect(new_path).to exist
+      end
+
+      context "and collections_dir is set" do
+        let(:collections_dir) { "my_collections" }
+        let(:posts_dir) { Pathname.new source_dir("site", collections_dir, "_posts") }
+        let(:config_data) do
+          %(
+        source: site
+        collections_dir: #{collections_dir}
+        )
+        end
+
+        it "should create posts at the correct location" do
+          expect(posts_dir).to exist
+          expect(old_path).to exist
+          expect(new_path).not_to exist
+          capture_stdout { described_class.process(args) }
+          expect(posts_dir).to exist
+          expect(old_path).not_to exist
+          expect(new_path).to exist
+        end
+
+        it "should write a helpful message when successful" do
+          output = capture_stdout { described_class.process(args) }
+          old_arg = File.join("site", collections_dir, "_posts", old_filename)
+          new_arg = File.join("site", collections_dir, "_posts", new_filename)
+          expect(output).to include("Post #{old_arg} was moved to #{new_arg}")
+        end
+      end
+    end
+
+    context "when source option is set" do
+      let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
+
+      it "should use source directory set by command line option" do
+        expect(old_path).to exist
+        expect(new_path).not_to exist
+        capture_stdout { described_class.process(args, "source" => "site") }
+        expect(old_path).not_to exist
+        expect(new_path).to exist
+      end
+    end
+  end
+end


### PR DESCRIPTION
`jekyll rename _drafts/my-old-draft.md "My New Draft"` will

- move the draft to _drafts/my-new-draft.md
- set the yaml front matter title attribute to "My New Draft"

`jekyll rename _drafts/my-old-draft.md "My New Draft" --date "2012-03-04"` will

- move the draft to _drafts/my-new-draft.md
- set the yaml front matter title attribute to "My New Draft"
- set the yaml front matter date to 2012-03-04

`jekyll rename _posts/2001-02-03-my-old-post.md "My New Post"` will

- move the post to _posts/2001-02-03-my-new-post.md
- set the yaml front matter title attribute to "My New Post"

`jekyll rename _posts/2001-02-03-my-old-post.md "My New Post" --date "2012-03-04"` will

- move the post to _posts/2012-03-04-my-new-post.md
- set the yaml front matter title attribute to "My New Post"
- set the yaml front matter date to 2012-03-04

`jekyll rename _posts/2001-02-03-my-old-post.md "My New Post" --now` will

- move the post to _posts/[now]-my-new-post.md
- set the yaml front matter title attribute to "My New Post"
- set the yaml front matter date to [now]

Closes #97 by @imabusabah.