### PR TITLE
Include VISUAL as an editor option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,13 +65,14 @@ To customize the default plugin configuration edit the `jekyll_compose` section 
     auto_open: true
 ```
 
-and make sure that you have `EDITOR` or `JEKYLL_EDITOR` environment variable set.
+and make sure that you have `EDITOR`, `VISUAL` or `JEKYLL_EDITOR` environment variable set.
 For instance if you wish to open newly created Jekyll posts and drafts in Atom editor you can add the following line in your shell configuration:
 ```
 export JEKYLL_EDITOR=atom
 ```
 
-The latter one will override default `EDITOR` value.
+`JEKYLL_EDITOR` will override default `EDITOR` or `VISUAL` value.
+`VISUAL` will override default `EDITOR` value.
 
 ### Set default front matter for drafts and posts
 

--- a/lib/jekyll-compose/file_editor.rb
+++ b/lib/jekyll-compose/file_editor.rb
@@ -9,7 +9,7 @@
 #    auto_open: true
 # ```
 #
-# And make sure, that you have JEKYLL_EDITOR or EDITOR environment variables set up.
+# And make sure, that you have JEKYLL_EDITOR, VISUAL, or EDITOR environment variables set up.
 # This will allow to open the file in your default editor automatically.
 
 module Jekyll
@@ -34,7 +34,7 @@ module Jekyll
         def post_editor
           return unless auto_open?
 
-          ENV["JEKYLL_EDITOR"] || ENV["EDITOR"]
+          ENV["JEKYLL_EDITOR"] || ENV["VISUAL"] || ENV["EDITOR"]
         end
 
         def auto_open?

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -139,12 +139,21 @@ RSpec.describe(Jekyll::Commands::Post) do
           capture_stdout { described_class.process(args) }
         end
 
-        context "env variable JEKYLL_EDITOR is set up" do
-          before { ENV["JEKYLL_EDITOR"] = "nano" }
+        context "env variable VISUAL is set up" do
+          before { ENV["VISUAL"] = "nano" }
 
           it "opens post in jekyll editor" do
             expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
             capture_stdout { described_class.process(args) }
+          end
+
+          context "env variable JEKYLL_EDITOR is set up" do
+            before { ENV["JEKYLL_EDITOR"] = "nano" }
+
+            it "opens post in jekyll editor" do
+              expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+              capture_stdout { described_class.process(args) }
+            end
           end
         end
       end


### PR DESCRIPTION
`JEKYLL_EDITOR` is the most specific and will still override `VISUAL` or `EDITOR`.

`VISUAL` will override `EDITOR` because apparently that's how bash works, and if this is unsatisfactory then setting `JEKYLL_EDITOR` will override both.

