### PR TITLE
Compose command for collections

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 1
-Lint/AmbiguousOperator:
-  Exclude:
-    - 'lib/jekyll/commands/compose.rb'
-
 # Offense count: 5
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,10 +6,16 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 3
+# Offense count: 1
+Lint/AmbiguousOperator:
+  Exclude:
+    - 'lib/jekyll/commands/compose.rb'
+
+# Offense count: 5
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
   Exclude:
     - 'lib/jekyll-compose/file_mover.rb'
+    - 'lib/jekyll/commands/compose.rb'
     - 'spec/publish_spec.rb'

--- a/README.md
+++ b/README.md
@@ -30,29 +30,74 @@ Listed in help you will see new commands available to you:
   publish    # Moves a draft into the _posts directory and sets the date
   unpublish  # Moves a post back into the _drafts directory
   page       # Creates a new page with the given NAME
+  compose    # Creates a new file with the given NAME
 ```
 
 Create your new page using:
 
+```sh
     $ bundle exec jekyll page "My New Page"
+```
 
 Create your new post using:
 
+```sh
     $ bundle exec jekyll post "My New Post"
+```
+
+```sh
+    # or by using the compose command
+    $ bundle exec jekyll compose "My New Post"
+```
+
+```sh
+    # or by using the compose command with post specified
+    $ bundle exec jekyll compose "My New Post" --post
+```
+
+```sh
+    # or by using the compose command with the posts collection specified
+    $ bundle exec jekyll compose "My New Post" --collection "posts"
+```
 
 Create your new draft using:
 
+```sh
     $ bundle exec jekyll draft "My new draft"
+```
+
+```sh
+    # or by using the compose command with draft specified
+    $ bundle exec jekyll compose "My new draft" --draft
+```
+
+```sh
+    # or by using the compose command with the drafts collection specified
+    $ bundle exec jekyll compose "My new draft" --collection "drafts"
+```
 
 Publish your draft using:
 
+```sh
     $ bundle exec jekyll publish _drafts/my-new-draft.md
+```
+
+```sh
     # or specify a specific date on which to publish it
     $ bundle exec jekyll publish _drafts/my-new-draft.md --date 2014-01-24
+```
 
 Unpublish your post using:
 
+```sh
     $ bundle exec jekyll unpublish _posts/2014-01-24-my-new-draft.md
+```
+
+Create your new file in a collection using:
+
+```sh
+    $ bundle exec jekyll compose "My New Thing" --collection "things"
+```
 
 ## Configuration
 
@@ -67,7 +112,7 @@ To customize the default plugin configuration edit the `jekyll_compose` section 
 
 and make sure that you have `EDITOR`, `VISUAL` or `JEKYLL_EDITOR` environment variable set.
 For instance if you wish to open newly created Jekyll posts and drafts in Atom editor you can add the following line in your shell configuration:
-```
+```sh
 export JEKYLL_EDITOR=atom
 ```
 
@@ -98,6 +143,19 @@ jekyll_compose:
 This will also auto add:
  - The creation timestamp under the `date` attribure.
  - The title attribute under the `title` attribute
+
+
+For collections, you can add default front matter to newly created collection files using `default_front_matter` and the collection name as a config key, for instance for the collection `things`:
+
+```yaml
+jekyll_compose:
+  default_front_matter:
+    things:
+      description:
+      image:
+      category:
+      tags:
+```
 
 ## Contributing
 

--- a/lib/jekyll-compose.rb
+++ b/lib/jekyll-compose.rb
@@ -18,6 +18,6 @@ module Jekyll
   end
 end
 
-%w(draft post publish unpublish page).each do |file|
+%w(draft post publish unpublish page compose).each do |file|
   require File.expand_path("jekyll/commands/#{file}.rb", __dir__)
 end

--- a/lib/jekyll/commands/compose.rb
+++ b/lib/jekyll/commands/compose.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+module Jekyll
+  module Commands
+    class ComposeCommand < Command
+      def self.init_with_program(prog)
+        prog.command(:compose) do |c|
+          c.syntax "compose NAME"
+          c.description "Creates a new document with the given NAME"
+
+          options.each { |opt| c.option *opt }
+
+          c.action { |args, options| process args, options }
+        end
+      end
+
+      def self.options
+        [
+          ["extension", "-x EXTENSION", "--extension EXTENSION", "Specify the file extension"],
+          ["layout", "-l LAYOUT", "--layout LAYOUT", "Specify the document layout"],
+          ["force", "-f", "--force", "Overwrite a document if it already exists"],
+          ["date", "-d DATE", "--date DATE", "Specify the document date"],
+          ["collection", "-c COLLECTION", "--collection COLLECTION", "Specify the document collection"],
+          ["post", "--post", "Create a new post (default)"],
+          ["draft", "--draft", "Create a new draft"],
+          ["config", "--config CONFIG_FILE[,CONFIG_FILE2,...]", Array, "Custom configuration file"],
+        ]
+      end
+
+      def self.process(args = [], options = {})
+        config = configuration_from_options(options)
+        params = ComposeCommandArgParser.new args, options, config
+        params.validate!
+
+        document = ComposeCommandFileInfo.new params
+
+        file_creator = Compose::FileCreator.new(document, params.force?, params.source)
+        file_creator.create!
+
+        Compose::FileEditor.bootstrap(config)
+        Compose::FileEditor.open_editor(file_creator.file_path)
+      end
+
+      class ComposeCommandArgParser < Compose::ArgParser
+        def validate!
+          if options.values_at("post", "draft", "collection").compact.length > 1
+            raise ArgumentError, "You can only specify one of --post, --draft, or --collection COLLECTION."
+          end
+
+          super
+        end
+
+        def date
+          options["date"] ? Date.parse(options["date"]) : Time.now
+        end
+
+        def collection
+          if options["collection"]
+            options["collection"]
+          elsif options["post"]
+            "posts"
+          elsif options["draft"]
+            "drafts"
+          else
+            "posts"
+          end
+        end
+      end
+
+      class ComposeCommandFileInfo < Compose::FileInfo
+        def resource_type
+          case @params.collection
+          when "posts" then "post"
+          when "drafts" then "draft"
+          else
+            "file"
+          end
+        end
+
+        def path
+          "#{_collection}/#{file_name}"
+        end
+
+        def file_name
+          @params.collection == "posts" ? "#{_date_stamp}-#{super}" : super
+        end
+
+        def _date_stamp
+          @params.date.strftime Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT
+        end
+
+        def _time_stamp
+          @params.date.strftime Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT
+        end
+
+        def _collection
+          "_#{@params.collection}"
+        end
+
+        def content(custom_front_matter = {})
+          default_front_matter =
+            case @params.collection
+            when "posts" then params.config.dig("jekyll_compose", "post_default_front_matter")
+            when "drafts"then params.config.dig("jekyll_compose", "draft_default_front_matter")
+            else
+              params.config.dig("jekyll_compose", "default_front_matter", @params.collection)
+            end
+
+          custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
+
+          super({ "date" => _time_stamp }.merge!(custom_front_matter))
+        end
+      end
+    end
+  end
+end

--- a/lib/jekyll/commands/compose.rb
+++ b/lib/jekyll/commands/compose.rb
@@ -89,14 +89,7 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          default_front_matter = \
-            case @collection
-            when "posts"  then params.config.dig("jekyll_compose", "post_default_front_matter")
-            when "drafts" then params.config.dig("jekyll_compose", "draft_default_front_matter")
-            else
-              params.config.dig("jekyll_compose", "default_front_matter", @collection)
-            end
-
+          default_front_matter = front_matter_defaults_for(@collection)
           custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super({ "date" => time_stamp }.merge!(custom_front_matter))

--- a/spec/compose_spec.rb
+++ b/spec/compose_spec.rb
@@ -1,0 +1,570 @@
+# frozen_string_literal: true
+
+RSpec.describe(Jekyll::Commands::ComposeCommand) do
+  let(:datestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_DATESTAMP_FORMAT) }
+  let(:timestamp) { Time.now.strftime(Jekyll::Compose::DEFAULT_TIMESTAMP_FORMAT) }
+  let(:posts_dir) { Pathname.new source_dir("_posts") }
+  let(:drafts_dir) { Pathname.new source_dir("_drafts") }
+  let(:things_dir) { Pathname.new source_dir("_things") }
+
+  before(:all) do
+    FileUtils.mkdir_p source_dir unless File.directory? source_dir
+    Dir.chdir source_dir
+  end
+
+  context "posts" do
+    let(:name) { "A test post" }
+    let(:args) { [name] }
+    let(:filename) { "#{datestamp}-a-test-post.md" }
+    let(:path) { posts_dir.join(filename) }
+
+    before(:each) do
+      FileUtils.mkdir_p posts_dir unless File.directory? posts_dir
+      allow(Jekyll::Compose::FileEditor).to receive(:system)
+    end
+
+    after(:each) do
+      FileUtils.rm_r posts_dir if File.directory? posts_dir
+    end
+
+    it "creates a new post" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args) }
+      expect(path).to exist
+    end
+
+    it "creates a new post with --post option" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, "post" => true) }
+      expect(path).to exist
+    end
+
+    it "creates a new post with --collection posts" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, "collection" => "posts") }
+      expect(path).to exist
+    end
+
+    it "creates a post with a specified date" do
+      path = posts_dir.join "2012-03-04-a-test-post.md"
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, "date" => "2012-3-4") }
+      expect(path).to exist
+      expect(File.read(path)).to match(%r!date: 2012-03-04 00:00 \+0000!)
+    end
+
+    it "creates the post with a specified extension" do
+      html_path = posts_dir.join "#{datestamp}-a-test-post.html"
+      expect(html_path).not_to exist
+      capture_stdout { described_class.process(args, "extension" => "html") }
+      expect(html_path).to exist
+    end
+
+    it "creates a new post with the specified layout" do
+      capture_stdout { described_class.process(args, "layout" => "other-layout") }
+      expect(File.read(path)).to match(%r!layout: other-layout!)
+    end
+
+    it "should write a helpful message when successful" do
+      output = capture_stdout { described_class.process(args) }
+      expect(output).to include("New post created at #{File.join("_posts", filename).cyan}")
+    end
+
+    it "errors with no arguments" do
+      expect(lambda {
+        capture_stdout { described_class.process }
+      }).to raise_error("You must specify a name.")
+    end
+
+    it "creates the posts folder if necessary" do
+      FileUtils.rm_r posts_dir if File.directory? posts_dir
+      capture_stdout { described_class.process(args) }
+      expect(posts_dir).to exist
+    end
+
+    context "when the post already exists" do
+      let(:name) { "An existing post" }
+      let(:filename) { "#{datestamp}-an-existing-post.md" }
+
+      before(:each) do
+        FileUtils.touch path
+      end
+
+      it "displays a warning and returns" do
+        output = capture_stdout { described_class.process(args) }
+        expect(output).to include("A post already exists at _posts/#{filename}")
+        expect(File.read(path)).to_not match("layout: post")
+      end
+
+      it "overwrites if --force is given" do
+        output = capture_stdout { described_class.process(args, "force" => true) }
+        expect(output).to_not include("A post already exists at _posts/#{filename}")
+        expect(File.read(path)).to match("layout: post")
+      end
+    end
+
+    context "when a configuration file exists" do
+      let(:config) { source_dir("_config.yml") }
+      let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
+      let(:config_data) do
+        %(
+      source: site
+      )
+      end
+
+      before(:each) do
+        File.open(config, "w") do |f|
+          f.write(config_data)
+        end
+      end
+
+      after(:each) do
+        FileUtils.rm(config)
+      end
+
+      it "should use source directory set by config" do
+        expect(path).not_to exist
+        capture_stdout { described_class.process(args) }
+        expect(path).to exist
+      end
+
+      context "configuration is set" do
+        let(:posts_dir) { Pathname.new source_dir("_posts") }
+        let(:config_data) do
+          %(
+        jekyll_compose:
+          auto_open: true
+          post_default_front_matter:
+            description: my description
+            category:
+        )
+        end
+
+        it "creates post with the specified config" do
+          capture_stdout { described_class.process(args) }
+          post = File.read(path)
+          expect(post).to match(%r!description: my description!)
+          expect(post).to match(%r!category: !)
+        end
+
+        context "env variable EDITOR is set up" do
+          before { ENV["EDITOR"] = "nano" }
+
+          it "opens post in default editor" do
+            expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+            capture_stdout { described_class.process(args) }
+          end
+
+          context "env variable JEKYLL_EDITOR is set up" do
+            before { ENV["JEKYLL_EDITOR"] = "nano" }
+
+            it "opens post in jekyll editor" do
+              expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+              capture_stdout { described_class.process(args) }
+            end
+          end
+        end
+      end
+
+      context "and collections_dir is set" do
+        let(:collections_dir) { "my_collections" }
+        let(:posts_dir) { Pathname.new source_dir("site", collections_dir, "_posts") }
+        let(:config_data) do
+          %(
+        source: site
+        collections_dir: #{collections_dir}
+        )
+        end
+
+        it "should create posts at the correct location" do
+          expect(path).not_to exist
+          capture_stdout { described_class.process(args) }
+          expect(path).to exist
+        end
+
+        it "should write a helpful message when successful" do
+          output = capture_stdout { described_class.process(args) }
+          generated_path = File.join("site", collections_dir, "_posts", filename).cyan
+          expect(output).to include("New post created at #{generated_path}")
+        end
+      end
+    end
+
+    context "when source option is set" do
+      let(:posts_dir) { Pathname.new source_dir("site", "_posts") }
+
+      it "should use source directory set by command line option" do
+        expect(path).not_to exist
+        capture_stdout { described_class.process(args, "source" => "site") }
+        expect(path).to exist
+      end
+    end
+  end
+  context "drafts" do
+    let(:name) { "A test draft" }
+    let(:args) { [name] }
+    let(:options) { { "draft" => true } }
+    let(:path) { drafts_dir.join("a-test-draft.md") }
+
+    before(:each) do
+      FileUtils.mkdir_p drafts_dir unless File.directory? drafts_dir
+      allow(Jekyll::Compose::FileEditor).to receive(:system)
+    end
+
+    after(:each) do
+      FileUtils.rm_r drafts_dir if File.directory? drafts_dir
+    end
+
+    it "creates a new draft" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, options) }
+      expect(path).to exist
+    end
+
+    it "creates a new draft with --draft option" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, "draft" => true) }
+      expect(path).to exist
+    end
+
+    it "creates a new draft with --collection drafts" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, "collection" => "drafts") }
+      expect(path).to exist
+    end
+
+    it "writes a helpful success message" do
+      output = capture_stdout { described_class.process(args, options) }
+      expect(output).to include("New draft created at #{"_drafts/a-test-draft.md".cyan}")
+    end
+
+    it "errors with no arguments" do
+      expect(lambda {
+        capture_stdout { described_class.process }
+      }).to raise_error("You must specify a name.")
+    end
+
+    it "errors with no arguments with draft option" do
+      expect(lambda {
+        capture_stdout { described_class.process([], options) }
+      }).to raise_error("You must specify a name.")
+    end
+
+    it "creates the drafts folder if necessary" do
+      FileUtils.rm_r drafts_dir if File.directory? drafts_dir
+      capture_stdout { described_class.process(args, options) }
+      expect(drafts_dir).to exist
+    end
+
+    it "creates the draft with a specified extension" do
+      html_path = drafts_dir.join "a-test-draft.html"
+      expect(html_path).not_to exist
+      capture_stdout { described_class.process(args, options.merge("extension" => "html")) }
+      expect(html_path).to exist
+    end
+
+    it "creates a new draft with the specified layout" do
+      capture_stdout { described_class.process(args, options.merge("layout" => "other-layout")) }
+      expect(File.read(path)).to match(%r!layout: other-layout!)
+    end
+
+    context "when the draft already exists" do
+      let(:name) { "An existing draft" }
+      let(:path) { drafts_dir.join("an-existing-draft.md") }
+
+      before(:each) do
+        FileUtils.touch path
+      end
+
+      it "displays a warning and returns" do
+        output = capture_stdout { described_class.process(args, options) }
+        expect(output).to include("A draft already exists at _drafts/an-existing-draft.md")
+        expect(File.read(path)).to_not match("layout: post")
+      end
+
+      it "overwrites if --force is given" do
+        output = capture_stdout { described_class.process(args, options.merge("force" => true)) }
+        expect(output).to_not include("A draft already exists at _drafts/an-existing-draft.md")
+        expect(File.read(path)).to match("layout: post")
+      end
+    end
+
+    context "when a configuration file exists" do
+      let(:config) { source_dir("_config.yml") }
+      let(:drafts_dir) { Pathname.new source_dir(File.join("site", "_drafts")) }
+      let(:config_data) do
+        %(
+      source: site
+      )
+      end
+
+      before(:each) do
+        File.open(config, "w") do |f|
+          f.write(config_data)
+        end
+      end
+
+      after(:each) do
+        FileUtils.rm(config)
+      end
+
+      it "should use source directory set by config" do
+        expect(path).not_to exist
+        capture_stdout { described_class.process(args, options) }
+        expect(path).to exist
+      end
+
+      context "configuration is set" do
+        let(:drafts_dir) { Pathname.new source_dir("_drafts") }
+        let(:config_data) do
+          %(
+        jekyll_compose:
+          auto_open: true
+          draft_default_front_matter:
+            description: my description
+            category:
+        )
+        end
+
+        it "creates post with the specified config" do
+          capture_stdout { described_class.process(args, options) }
+          post = File.read(path)
+          expect(post).to match(%r!description: my description!)
+          expect(post).to match(%r!category: !)
+        end
+
+        context "env variable EDITOR is set up" do
+          before { ENV["EDITOR"] = "nano" }
+
+          it "opens post in default editor" do
+            expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+            capture_stdout { described_class.process(args, options) }
+          end
+
+          context "env variable JEKYLL_EDITOR is set up" do
+            before { ENV["JEKYLL_EDITOR"] = "nano" }
+
+            it "opens post in jekyll editor" do
+              expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+              capture_stdout { described_class.process(args, options) }
+            end
+          end
+        end
+      end
+
+      context "and collections_dir is set" do
+        let(:collections_dir) { "my_collections" }
+        let(:drafts_dir) { Pathname.new source_dir("site", collections_dir, "_drafts") }
+        let(:config_data) do
+          %(
+        source: site
+        collections_dir: #{collections_dir}
+        )
+        end
+
+        it "should create drafts at the correct location" do
+          expect(path).not_to exist
+          capture_stdout { described_class.process(args, options) }
+          expect(path).to exist
+        end
+
+        it "should write a helpful message when successful" do
+          output = capture_stdout { described_class.process(args, options) }
+          generated_path = File.join("site", collections_dir, "_drafts", "a-test-draft.md").cyan
+          expect(output).to include("New draft created at #{generated_path}")
+        end
+      end
+    end
+
+    context "when source option is set" do
+      let(:drafts_dir) { Pathname.new source_dir(File.join("site", "_drafts")) }
+
+      it "should use source directory set by command line option" do
+        expect(path).not_to exist
+        capture_stdout { described_class.process(args, options.merge("source" => "site")) }
+        expect(path).to exist
+      end
+    end
+  end
+  context "collections" do
+    let(:name) { "A test thing" }
+    let(:args) { [name] }
+    let(:options) { { "collection" => "things" } }
+    let(:path) { things_dir.join("a-test-thing.md") }
+
+    before(:each) do
+      FileUtils.mkdir_p things_dir unless File.directory? things_dir
+      allow(Jekyll::Compose::FileEditor).to receive(:system)
+    end
+
+    after(:each) do
+      FileUtils.rm_r things_dir if File.directory? things_dir
+    end
+
+    it "creates a new collection file" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, options) }
+      expect(path).to exist
+    end
+
+    it "creates a new collection file with --collection things option" do
+      expect(path).not_to exist
+      capture_stdout { described_class.process(args, "collection" => "things") }
+      expect(path).to exist
+    end
+
+    it "writes a helpful success message" do
+      output = capture_stdout { described_class.process(args, options) }
+      expect(output).to include("New file created at #{"_things/a-test-thing.md".cyan}")
+    end
+
+    it "errors with no arguments" do
+      expect(lambda {
+        capture_stdout { described_class.process }
+      }).to raise_error("You must specify a name.")
+    end
+
+    it "errors with no arguments with collection option" do
+      expect(lambda {
+        capture_stdout { described_class.process([], options) }
+      }).to raise_error("You must specify a name.")
+    end
+
+    it "creates the collection folder if necessary" do
+      FileUtils.rm_r things_dir if File.directory? things_dir
+      capture_stdout { described_class.process(args, options) }
+      expect(things_dir).to exist
+    end
+
+    it "creates the collection file with a specified extension" do
+      html_path = things_dir.join "a-test-thing.html"
+      expect(html_path).not_to exist
+      capture_stdout { described_class.process(args, options.merge("extension" => "html")) }
+      expect(html_path).to exist
+    end
+
+    it "creates a new collection item with the specified layout" do
+      capture_stdout { described_class.process(args, options.merge("layout" => "other-layout")) }
+      expect(File.read(path)).to match(%r!layout: other-layout!)
+    end
+
+    context "when the collection file already exists" do
+      let(:name) { "An existing thing" }
+      let(:path) { things_dir.join("an-existing-thing.md") }
+
+      before(:each) do
+        FileUtils.touch path
+      end
+
+      it "displays a warning and returns" do
+        output = capture_stdout { described_class.process(args, options) }
+        expect(output).to include("A file already exists at _things/an-existing-thing.md")
+        expect(File.read(path)).to_not match("layout: post")
+      end
+
+      it "overwrites if --force is given" do
+        output = capture_stdout { described_class.process(args, options.merge("force" => true)) }
+        expect(output).to_not include("A file already exists at _things/an-existing-thing.md")
+        expect(File.read(path)).to match("layout: post")
+      end
+    end
+
+    context "when a configuration file exists" do
+      let(:config) { source_dir("_config.yml") }
+      let(:things_dir) { Pathname.new source_dir(File.join("site", "_things")) }
+      let(:config_data) do
+        %(
+      source: site
+      )
+      end
+
+      before(:each) do
+        File.open(config, "w") do |f|
+          f.write(config_data)
+        end
+      end
+
+      after(:each) do
+        FileUtils.rm(config)
+      end
+
+      it "should use source directory set by config" do
+        expect(path).not_to exist
+        capture_stdout { described_class.process(args, options) }
+        expect(path).to exist
+      end
+
+      context "configuration is set" do
+        let(:things_dir) { Pathname.new source_dir("_things") }
+        let(:config_data) do
+          %(
+        jekyll_compose:
+          auto_open: true
+          default_front_matter:
+            things:
+              description: my description
+              category:
+        )
+        end
+
+        it "creates collection item with the specified config" do
+          capture_stdout { described_class.process(args, options) }
+          post = File.read(path)
+          expect(post).to match(%r!description: my description!)
+          expect(post).to match(%r!category: !)
+        end
+
+        context "env variable EDITOR is set up" do
+          before { ENV["EDITOR"] = "nano" }
+
+          it "opens collection item in default editor" do
+            expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+            capture_stdout { described_class.process(args, options) }
+          end
+
+          context "env variable JEKYLL_EDITOR is set up" do
+            before { ENV["JEKYLL_EDITOR"] = "nano" }
+
+            it "opens post in jekyll editor" do
+              expect(Jekyll::Compose::FileEditor).to receive(:run_editor).with("nano", path.to_s)
+              capture_stdout { described_class.process(args, options) }
+            end
+          end
+        end
+      end
+
+      context "and collections_dir is set" do
+        let(:collections_dir) { "my_collections" }
+        let(:things_dir) { Pathname.new source_dir("site", collections_dir, "_things") }
+        let(:config_data) do
+          %(
+        source: site
+        collections_dir: #{collections_dir}
+        )
+        end
+
+        it "should create collection files at the correct location" do
+          expect(path).not_to exist
+          capture_stdout { described_class.process(args, options) }
+          expect(path).to exist
+        end
+
+        it "should write a helpful message when successful" do
+          output = capture_stdout { described_class.process(args, options) }
+          generated_path = File.join("site", collections_dir, "_things", "a-test-thing.md").cyan
+          expect(output).to include("New file created at #{generated_path}")
+        end
+      end
+    end
+
+    context "when source option is set" do
+      let(:things_dir) { Pathname.new source_dir(File.join("site", "_things")) }
+
+      it "should use source directory set by command line option" do
+        expect(path).not_to exist
+        capture_stdout { described_class.process(args, options.merge("source" => "site")) }
+        expect(path).to exist
+      end
+    end
+  end
+end

--- a/spec/compose_spec.rb
+++ b/spec/compose_spec.rb
@@ -134,9 +134,10 @@ RSpec.describe(Jekyll::Commands::ComposeCommand) do
           %(
         jekyll_compose:
           auto_open: true
-          post_default_front_matter:
-            description: my description
-            category:
+          default_front_matter:
+            posts:
+              description: my description
+              category:
         )
         end
 
@@ -320,9 +321,10 @@ RSpec.describe(Jekyll::Commands::ComposeCommand) do
           %(
         jekyll_compose:
           auto_open: true
-          draft_default_front_matter:
-            description: my description
-            category:
+          default_front_matter:
+            drafts:
+              description: my description
+              category:
         )
         end
 


### PR DESCRIPTION
This allows creating files in collections, including posts and drafts.

`jekyll compose "My New Post"`
`jekyll compose "My New Post" --post`

`jekyll compose "My new draft" --draft`

`jekyll compose "My New Thing" --collection "things"`

Default front matter can be specified for each collection.

```
jekyll_compose:
  default_front_matter:
    drafts:
      layout: post
      category:
      tags:
    posts:
      published: false
      sitemap: false
    things:
      layout: thing
```

Closes #84 