### PR TITLE
Prepare for collections support with default front matter configuration

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,12 +13,14 @@ Lint/AmbiguousOperator:
     - 'lib/jekyll/commands/page.rb'
     - 'lib/jekyll/commands/post.rb'
 
-# Offense count: 6
+# Offense count: 8
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
   Exclude:
     - 'lib/jekyll-compose/file_mover.rb'
+    - 'lib/jekyll/commands/draft.rb'
+    - 'lib/jekyll/commands/post.rb'
     - 'lib/jekyll/commands/publish.rb'
     - 'lib/jekyll/commands/unpublish.rb'
     - 'spec/post_spec.rb'

--- a/README.md
+++ b/README.md
@@ -76,22 +76,23 @@ export JEKYLL_EDITOR=atom
 
 ### Set default front matter for drafts and posts
 
-If you wish to add default front matter to newly created posts or drafts, you can specify as many as you want under `draft_default_front_matter` and `post_default_front_matter`config keys, for instance:
+If you wish to add default front matter to newly created posts or drafts, you can specify as many as you want under `default_front_matter` config keys, for instance:
 
 ```yaml
 jekyll_compose:
-  draft_default_front_matter:
-    description:
-    image:
-    category:
-    tags:
-  post_default_front_matter:
-    description:
-    image:
-    category:
-    tags:
-    published: false
-    sitemap: false
+  default_front_matter:
+    drafts:
+      description:
+      image:
+      category:
+      tags:
+    posts:
+      description:
+      image:
+      category:
+      tags:
+      published: false
+      sitemap: false
 ```
 
 This will also auto add:

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -47,7 +47,7 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          default_front_matter = params.config.dig("jekyll_compose", "draft_default_front_matter")
+          default_front_matter = params.config.dig("jekyll_compose", "default_front_matter", "drafts")
           custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super(custom_front_matter)

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -66,7 +66,7 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          default_front_matter = params.config.dig("jekyll_compose", "post_default_front_matter")
+          default_front_matter = params.config.dig("jekyll_compose", "default_front_matter", "posts")
           custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super({ "date" => _time_stamp }.merge(custom_front_matter))

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -107,9 +107,10 @@ RSpec.describe(Jekyll::Commands::Draft) do
         %(
       jekyll_compose:
         auto_open: true
-        draft_default_front_matter:
-          description: my description
-          category:
+        default_front_matter:
+          drafts:
+            description: my description
+            category:
       )
       end
 

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -118,9 +118,10 @@ RSpec.describe(Jekyll::Commands::Post) do
         %(
       jekyll_compose:
         auto_open: true
-        post_default_front_matter:
-          description: my description
-          category:
+        default_front_matter:
+          posts:
+            description: my description
+            category:
       )
       end
 


### PR DESCRIPTION
This PR changes how default front matter is configured in preparation for user defined collections.

The previous structure for default front matter is:

```
jekyll_compose:
  draft_default_front_matter:
    description:
    image:
    category:
    tags:
  post_default_front_matter:
    description:
    image:
    category:
    tags:
    published: false
    sitemap: false
```

Instead of configuration keys of the form `post_default_front_matter` and `draft_default_front_matter`, which can only support default front matter only for posts and drafts, the new proposed structure is:

```
jekyll_compose:
  default_front_matter:
    drafts:
      description:
      image:
      category:
      tags:
    posts:
      description:
      image:
      category:
      tags:
      published: false
      sitemap: false
```

This could allow for default front matter for user defined collections by configuring as follows:

```
jekyll_compose:
  default_front_matter:
    [ as above ]
    things:
      description:
      image:
      category:
      tags:
```

This then makes accessing default front matter for any collection based upon the collection's name or path, without special cases being required for posts and drafts.