### PR TITLE
Extract logic for computing default front matter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,14 +13,12 @@ Lint/AmbiguousOperator:
     - 'lib/jekyll/commands/page.rb'
     - 'lib/jekyll/commands/post.rb'
 
-# Offense count: 8
+# Offense count: 6
 # Configuration parameters: Max, AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
 # URISchemes: http, https
 Metrics/LineLength:
   Exclude:
     - 'lib/jekyll-compose/file_mover.rb'
-    - 'lib/jekyll/commands/draft.rb'
-    - 'lib/jekyll/commands/post.rb'
     - 'lib/jekyll/commands/publish.rb'
     - 'lib/jekyll/commands/unpublish.rb'
     - 'spec/post_spec.rb'

--- a/lib/jekyll-compose/file_info.rb
+++ b/lib/jekyll-compose/file_info.rb
@@ -21,6 +21,12 @@ module Jekyll
 
         front_matter + "---\n"
       end
+
+      private
+
+      def front_matter_defaults_for(key)
+        params.config.dig("jekyll_compose", "default_front_matter", key)
+      end
     end
   end
 end

--- a/lib/jekyll/commands/draft.rb
+++ b/lib/jekyll/commands/draft.rb
@@ -47,7 +47,7 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          default_front_matter = params.config.dig("jekyll_compose", "default_front_matter", "drafts")
+          default_front_matter = front_matter_defaults_for("drafts")
           custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super(custom_front_matter)

--- a/lib/jekyll/commands/post.rb
+++ b/lib/jekyll/commands/post.rb
@@ -66,7 +66,7 @@ module Jekyll
         end
 
         def content(custom_front_matter = {})
-          default_front_matter = params.config.dig("jekyll_compose", "default_front_matter", "posts")
+          default_front_matter = front_matter_defaults_for("posts")
           custom_front_matter.merge!(default_front_matter) if default_front_matter.is_a?(Hash)
 
           super({ "date" => _time_stamp }.merge(custom_front_matter))


### PR DESCRIPTION
## Rationale

- Centralizing logic to allow future changes to the *config dig sequence
(`"jekyll_compose"` => `"default_front_matter"` => `"posts" / "drafts" / "<collection>"`)* be made at a single place.
- Reduced line-lengths