### PR TITLE
Fix tests and warning when running publish/unpublish with date in frontmatter

### DIFF
--- a/lib/jekyll-compose/file_mover.rb
+++ b/lib/jekyll-compose/file_mover.rb
@@ -53,7 +53,7 @@ module Jekyll
         if content =~ Jekyll::Document::YAML_FRONT_MATTER_REGEXP
           content = $POSTMATCH
           match = Regexp.last_match[1] if Regexp.last_match
-          data = movement.front_matter(Psych.safe_load(match))
+          data = movement.front_matter(Psych.safe_load(match, permitted_classes: [Date, Time]))
           File.write(from, "#{Psych.dump(data)}---\n#{content}")
         end
       rescue Psych::SyntaxError => e

--- a/spec/compose_spec.rb
+++ b/spec/compose_spec.rb
@@ -145,7 +145,7 @@ RSpec.describe(Jekyll::Commands::ComposeCommand) do
           capture_stdout { described_class.process(args) }
           post = File.read(path)
           expect(post).to match(%r!description: my description!)
-          expect(post).to match(%r!category: !)
+          expect(post).to match(%r!category:!)
         end
 
         context "env variable EDITOR is set up" do
@@ -332,7 +332,7 @@ RSpec.describe(Jekyll::Commands::ComposeCommand) do
           capture_stdout { described_class.process(args, options) }
           post = File.read(path)
           expect(post).to match(%r!description: my description!)
-          expect(post).to match(%r!category: !)
+          expect(post).to match(%r!category:!)
         end
 
         context "env variable EDITOR is set up" do
@@ -513,7 +513,7 @@ RSpec.describe(Jekyll::Commands::ComposeCommand) do
           capture_stdout { described_class.process(args, options) }
           post = File.read(path)
           expect(post).to match(%r!description: my description!)
-          expect(post).to match(%r!category: !)
+          expect(post).to match(%r!category:!)
         end
 
         context "env variable EDITOR is set up" do

--- a/spec/draft_spec.rb
+++ b/spec/draft_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe(Jekyll::Commands::Draft) do
         capture_stdout { described_class.process(args) }
         post = File.read(path)
         expect(post).to match(%r!description: my description!)
-        expect(post).to match(%r!category: !)
+        expect(post).to match(%r!category:!)
       end
 
       context "env variable EDITOR is set up" do

--- a/spec/post_spec.rb
+++ b/spec/post_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe(Jekyll::Commands::Post) do
         capture_stdout { described_class.process(args) }
         post = File.read(path)
         expect(post).to match(%r!description: my description!)
-        expect(post).to match(%r!category: !)
+        expect(post).to match(%r!category:!)
       end
 
       context "env variable EDITOR is set up" do


### PR DESCRIPTION
This PR does two things:

1. Fixes several failing unit tests due to trailing whitespace being removed in generated frontmatter
2. Fixes #125 . This warning was due to the fact that `Psych.safe_load` does not deserialize `Date` or `Time`. This PR adds those two classes as permitted for deserialization.